### PR TITLE
Fix section edit handling

### DIFF
--- a/action.php
+++ b/action.php
@@ -21,6 +21,7 @@ class action_plugin_wrap extends DokuWiki_Action_Plugin {
      */
     function register(&$controller){
         $controller->register_hook('TOOLBAR_DEFINE', 'AFTER', $this, 'handle_toolbar', array ());
+        $controller->register_hook('HTML_SECEDIT_BUTTON', 'BEFORE', $this, 'handle_secedit_button');
     }
 
     function handle_toolbar(&$event, $param) {
@@ -121,6 +122,28 @@ class action_plugin_wrap extends DokuWiki_Action_Plugin {
                 ),
             )
         );
+    }
+
+    /**
+     * Handle section edit buttons, prevents section buttons inside the wrap plugin from being displayed
+     *
+     * @param Doku_Event $event The event object
+     * @param array      $args Parameters for the event
+     */
+    public function handle_secedit_button($event, $args) {
+        // counter of the number of currently opened wraps
+        static $wraps = 0;
+        $data = $event->data;
+
+        if ($data['target'] == 'plugin_wrap_start') {
+            ++$wraps;
+        } elseif ($data['target'] == 'plugin_wrap_end') {
+            --$wraps;
+        } elseif ($wraps > 0 && $data['target'] == 'section') {
+            $event->preventDefault();
+            $event->stopPropagation();
+            $event->result = '';
+        }
     }
 }
 

--- a/syntax/closesection.php
+++ b/syntax/closesection.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Section close helper of the Wrap Plugin
+ *
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author     Michael Hamann <michael@content-space.de>
+ */
+
+if(!defined('DOKU_INC')) die();
+
+if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
+require_once(DOKU_PLUGIN.'syntax.php');
+
+class syntax_plugin_wrap_closesection extends DokuWiki_Syntax_Plugin {
+
+    function getType(){ return 'formatting';}
+    function getSort(){ return 195; }
+
+    /**
+     * Dummy handler, this syntax part has no syntax but is directly added to the instructions by the div syntax
+     */
+    function handle($match, $state, $pos, &$handler){
+    }
+
+    /**
+     * Create output
+     */
+    function render($mode, &$renderer, $indata) {
+        if($mode == 'xhtml'){
+            /** @var Doku_Renderer_xhtml $renderer */
+            $renderer->finishSectionEdit();
+            return true;
+        }
+        return false;
+    }
+
+
+}
+


### PR DESCRIPTION
This prevents section edit buttons from being displayed inside the wrap
content and makes sure that the section edit button after the wrap is
for the section the wrap syntax is in and not for a section that is
started inside the wrap.

This also fixes the strange behavior of section highlights.
