### PR TITLE
Only hide section edit buttons and not table/data/... edit buttons

### DIFF
--- a/all.css
+++ b/all.css
@@ -39,7 +39,7 @@ Screen and Print Styles for the Wrap Plugin
     margin-right: 0;
 }
 /* hide section edit buttons (because they don't work inside a wrap) */
-.dokuwiki .plugin_wrap div.secedit {
+.dokuwiki .plugin_wrap div.editbutton_section {
     display: none;
 }
 


### PR DESCRIPTION
There is no obvious reason to hide table or data edit buttons as they work very well inside the wrap plugin. This problem was reported in [the forum](https://forum.dokuwiki.org/thread/8984).

With my new section edit button hiding code in theory this CSS code could be completely removed but there might be problems with plugins like the include plugin. If these problems occur, the section edit buttons inside the wrap content will be displayed so it is better to keep the CSS code that hides them.
