### PR TITLE
Partial support for ODT export

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -11,7 +11,8 @@ if(!defined('DOKU_INC')) die();
 
 class helper_plugin_wrap extends DokuWiki_Plugin {
     public $known_odt_styles = array ("box", "info", "important", "alert", "tip", "help", "todo", "download",
-                                      "danger", "warning", "caution", "notice", "safety", "hi", "lo", "em", "column");
+                                      "danger", "warning", "caution", "notice", "safety", "hi", "lo", "em",
+                                      "column", "spoiler");
 
     // For each style list the background color and the name of the corresponding image, if any.
     // Color values like #eee do not work in odt so they need to be expanded to #e0e0e0.
@@ -102,6 +103,11 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
                                                      "picture" => NULL ),
                                "column"    => array ("type"     => "column",
                                                      "fo_color" => "#000000",
+                                                     "bg_color" => "#ffffff",
+                                                     "style"    => NULL,
+                                                     "picture" => NULL ),
+                               "spoiler"   => array ("type"     => "mark",
+                                                     "fo_color" => "#ffffff",
                                                      "bg_color" => "#ffffff",
                                                      "style"    => NULL,
                                                      "picture" => NULL ),

--- a/helper.php
+++ b/helper.php
@@ -169,8 +169,14 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
                 }
             }
 
+            // get odt alignment
             if ( $token == 'left' || $token == 'center' || $token == 'right' ) {
                 $attr['odt_align'] = $token;
+            }
+
+            // get odt round corners
+            if ( $token == 'round' ) {
+                $attr['odt_round'] = 'true';
             }
         }
 
@@ -249,6 +255,9 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
             }
             if($attr['odt_style']) {
                 $out .= ' odt_align="'.$attr['odt_align'].'"';
+            }
+            if($attr['odt_round']) {
+                $out .= ' odt_round="'.$attr['odt_round'].'"';
             }
         }
 

--- a/helper.php
+++ b/helper.php
@@ -10,6 +10,102 @@
 if(!defined('DOKU_INC')) die();
 
 class helper_plugin_wrap extends DokuWiki_Plugin {
+    public $known_odt_styles = array ("box", "info", "important", "alert", "tip", "help", "todo", "download",
+                                      "danger", "warning", "caution", "notice", "safety", "hi", "lo", "em", "column");
+
+    // For each style list the background color and the name of the corresponding image, if any.
+    // Color values like #eee do not work in odt so they need to be expanded to #e0e0e0.
+    public $odt_styles = array("default"   => array ("type"     => "mark",
+                                                     "fo_color" => "#000000",
+                                                     "bg_color" => "#ffffff",
+                                                     "style"    => NULL,
+                                                     "picture" => NULL ),
+                               "box"       => array ("type"     => "container",
+                                                     "fo_color" => "#000000",
+                                                     "bg_color" => "#eeeeee",
+                                                     "style"    => NULL,
+                                                     "picture" => NULL ),
+                               "info"      => array ("type"     => "container",
+                                                     "fo_color" => "#000000",
+                                                     "bg_color" => "#d1d7df",
+                                                     "style"    => NULL,
+                                                     "picture" => "info.png" ),
+                               "important" => array ("type"     => "container",
+                                                     "fo_color" => "#000000",
+                                                     "bg_color" => "#ffd39f",
+                                                     "style"    => NULL,
+                                                     "picture" => "important.png" ),
+                               "alert"     => array ("type"     => "container",
+                                                     "fo_color" => "#000000",
+                                                     "bg_color" => "#ffbcaf",
+                                                     "style"    => NULL,
+                                                     "picture" => "alert.png" ),
+                               "tip"       => array ("type"     => "container",
+                                                     "fo_color" => "#000000",
+                                                     "bg_color" => "#fff79f",
+                                                     "style"    => NULL,
+                                                     "picture" => "tip.png" ),
+                               "help"      => array ("type"     => "container",
+                                                     "fo_color" => "#000000",
+                                                     "bg_color" => "#dcc2ef",
+                                                     "style"    => NULL,
+                                                     "picture" => "help.png" ),
+                               "todo"      => array ("type"     => "container",
+                                                     "fo_color" => "#000000",
+                                                     "bg_color" => "#c2efdd",
+                                                     "style"    => NULL,
+                                                     "picture" => "todo.png" ),
+                               "download"  => array ("type"     => "container",
+                                                     "fo_color" => "#000000",
+                                                     "bg_color" => "#c2efdd",
+                                                     "style"    => NULL,
+                                                     "picture" => "download.png" ),
+                               "danger"    => array ("type"     => "container",
+                                                     "fo_color" => "#ffffff",
+                                                     "bg_color" => "#cc0000",
+                                                     "style"    => NULL,
+                                                     "picture" => NULL ),
+                               "warning"   => array ("type"     => "container",
+                                                     "fo_color" => "#000000",
+                                                     "bg_color" => "#ff6600",
+                                                     "style"    => NULL,
+                                                     "picture" => NULL ),
+                               "caution"   => array ("type"     => "container",
+                                                     "fo_color" => "#000000",
+                                                     "bg_color" => "#ffff00",
+                                                     "style"    => NULL,
+                                                     "picture" => NULL ),
+                               "notice"    => array ("type"     => "container",
+                                                     "fo_color" => "#ffffff",
+                                                     "bg_color" => "#0066ff",
+                                                     "style"    => NULL,
+                                                     "picture" => NULL ),
+                               "safety"    => array ("type"     => "container",
+                                                     "fo_color" => "#ffffff",
+                                                     "bg_color" => "#009900",
+                                                     "style"    => NULL,
+                                                     "picture" => NULL ),
+                               "hi"        => array ("type"     => "mark",
+                                                     "fo_color" => "#000000",
+                                                     "bg_color" => "#ffff99",
+                                                     "style"    => NULL,
+                                                     "picture" => NULL ),
+                               "lo"        => array ("type"     => "mark",
+                                                     "fo_color" => "#666666",
+                                                     "bg_color" => "#ffffff",
+                                                     "style"    => "subscript",
+                                                     "picture" => NULL ),
+                               "em"        => array ("type"     => "mark",
+                                                     "fo_color" => "#cc0000",
+                                                     "bg_color" => "#ffffff",
+                                                     "style"    => "strong",
+                                                     "picture" => NULL ),
+                               "column"    => array ("type"     => "column",
+                                                     "fo_color" => "#000000",
+                                                     "bg_color" => "#ffffff",
+                                                     "style"    => NULL,
+                                                     "picture" => NULL ),
+                               );
 
     /**
      * get attributes (pull apart the string between '<wrap' and '>')
@@ -65,6 +161,13 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
             }
             $prefix = in_array($token, $noPrefix) ? '' : 'wrap_';
             $attr['class'] = (isset($attr['class']) ? $attr['class'].' ' : '').$prefix.$token;
+
+            // get odt style
+            foreach ($this->known_odt_styles as $style) {
+                if ( $style == $token ) {
+                    $attr['odt_style'] = $token;
+                }
+            }
         }
 
         //get dir
@@ -103,6 +206,43 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
             }
             // only write lang if it's a language in lang2dir.conf
             if($attr['dir'])   $out .= ' lang="'.$attr['lang'].'" xml:lang="'.$attr['lang'].'" dir="'.$attr['dir'].'"';
+        }
+        if ($mode=='odt') {
+            if($attr['class']) $out .= ' class="'.hsc($attr['class']).' '.$addClass.'"';
+            // if used in other plugins, they might want to add their own class(es)
+            elseif($addClass)  $out .= ' class="'.$addClass.'"';
+            if($attr['id'])    $out .= ' id="'.hsc($attr['id']).'"';
+            // width on spans normally doesn't make much sense, but in the case of floating elements it could be used
+            if($attr['width']) {
+                if (strpos($attr['width'],'%') !== false) {
+                    $out .= ' width="'.hsc($attr['width']).'"';
+                } else {
+                    // anything but % should be 100% when the screen gets smaller
+                    $out .= ' width=" '.hsc($attr['width']).'"'; //; max-width: 100%;"';
+                }
+            }
+            // only write lang if it's a language in lang2dir.conf
+            if($attr['dir'])   $out .= ' lang="'.$attr['lang'].'" xml:lang="'.$attr['lang'].'" dir="'.$attr['dir'].'"';
+            // if the style is known get it's properties otherwise use default style properties
+            if($attr['odt_style']) {
+                $out .= ' odt_style="'.$attr['odt_style'].'"';
+                $out .= ' odt_type="'.$this->odt_styles[$attr['odt_style']]['type'].'"';
+                $out .= ' odt_bg="'.$this->odt_styles[$attr['odt_style']]['bg_color'].'"';
+                $out .= ' odt_fo="'.$this->odt_styles[$attr['odt_style']]['fo_color'].'"';
+                if ( $this->odt_styles[$attr['odt_style']]['style'] != NULL )
+                    $out .= ' odt_fo_style="'.$this->odt_styles[$attr['odt_style']]['style'].'"';
+                if ( $this->odt_styles[$attr['odt_style']]['picture'] != NULL )
+                    $out .= ' odt_pic="'.$this->odt_styles[$attr['odt_style']]['picture'].'"';
+            } else {
+                $out .= ' odt_style="default"';
+                $out .= ' odt_type="'.$this->odt_styles['default']['type'].'"';
+                $out .= ' odt_bg="'.$this->odt_styles['default']['bg_color'].'"';
+                $out .= ' odt_fo="'.$this->odt_styles['default']['fo_color'].'"';
+                if ( $this->odt_styles['default']['style'] != NULL )
+                    $out .= ' odt_fo_style="'.$this->odt_styles['default']['style'].'"';
+                if ( $this->odt_styles['default']['picture'] != NULL )
+                    $out .= ' odt_pic="'.$this->odt_styles['default']['picture'].'"';
+            }
         }
 
         return $out;

--- a/helper.php
+++ b/helper.php
@@ -168,6 +168,10 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
                     $attr['odt_style'] = $token;
                 }
             }
+
+            if ( $token == 'left' || $token == 'center' || $token == 'right' ) {
+                $attr['odt_align'] = $token;
+            }
         }
 
         //get dir
@@ -242,6 +246,9 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
                     $out .= ' odt_fo_style="'.$this->odt_styles['default']['style'].'"';
                 if ( $this->odt_styles['default']['picture'] != NULL )
                     $out .= ' odt_pic="'.$this->odt_styles['default']['picture'].'"';
+            }
+            if($attr['odt_style']) {
+                $out .= ' odt_align="'.$attr['odt_align'].'"';
             }
         }
 

--- a/helper.php
+++ b/helper.php
@@ -178,6 +178,17 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
             if ( $token == 'round' ) {
                 $attr['odt_round'] = 'true';
             }
+
+            // get odt display setting
+            if ( $token == 'hide' ) {
+                $attr['odt_display'] = 'none';
+            }
+            if ( $token == 'noprint' ) {
+                $attr['odt_display'] = 'screen';
+            }
+            if ( $token == 'onlyprint' ) {
+                $attr['odt_display'] = 'printer';
+            }
         }
 
         //get dir
@@ -258,6 +269,9 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
             }
             if($attr['odt_round']) {
                 $out .= ' odt_round="'.$attr['odt_round'].'"';
+            }
+            if($attr['odt_display']) {
+                $out .= ' odt_display="'.$attr['odt_display'].'"';
             }
         }
 

--- a/syntax/div.php
+++ b/syntax/div.php
@@ -15,6 +15,10 @@ class syntax_plugin_wrap_div extends DokuWiki_Syntax_Plugin {
 
     protected $entry_pattern = '<div.*?>(?=.*?</div>)';
     protected $exit_pattern  = '</div>';
+    protected $columns_open = 0;
+    protected $odt_type;
+    protected $odt_fo_style;
+    protected $odt_ignore;
 
     function getType(){ return 'formatting';}
     function getAllowedTypes() { return array('container', 'formatting', 'substition', 'protected', 'disabled', 'paragraphs'); }
@@ -108,9 +112,219 @@ class syntax_plugin_wrap_div extends DokuWiki_Syntax_Plugin {
             }
             return true;
         }
+        if($mode == 'odt'){
+            switch ($state) {
+                case DOKU_LEXER_ENTER:
+                    $this->odt_ignore = $this->_odtVersionToOld($renderer);
+                    if ( $this->odt_ignore == true ) {
+                        $renderer->doc .= '<text:p>WRAP: ODT plugin version 2014-10-04 or newer required!</text:p>';
+                        return false;
+                    }
+
+                    // Get attributes.
+                    $wrap =& plugin_load('helper', 'wrap');
+                    $attr = $wrap->buildAttributes($data, 'plugin_wrap',$mode);
+
+                    // Parse attributes.
+                    $token = explode(' ', $attr);
+                    $width=$renderer->_getRelWidthMindMargins();
+                    $round=false;
+                    $odt_style='NOT FOUND!!!';
+                    $odt_bg='#FFFFFF';
+                    $odt_fo='#000000';
+                    $picture=NULL;
+                    $class=NULL;
+                    $this->odt_type=NULL;
+                    foreach ($token as $i => $value) {
+                        if ( substr($value,0,6) == 'width=' )
+                        {
+                            $width = trim(substr($value,7), '"');
+                            $width = trim($width, '%');
+                            $width = $renderer->_getRelWidthMindMargins($width);
+                            continue;
+                        }
+                        if ( substr($value,0,6) == 'class=' )
+                        {
+                            $class = trim(substr($value,7), '"');
+                            continue;
+                        }
+                        if ( substr($value,0,10) == 'odt_style=' )
+                        {
+                            $odt_style = trim(substr($value,10), '"');
+                            continue;
+                        }
+                        if ( substr($value,0,9) == 'odt_type=' )
+                        {
+                            $this->odt_type = trim(substr($value,10), '"');
+                            continue;
+                        }
+                        if ( substr($value,0,7) == 'odt_bg=' )
+                        {
+                            $odt_bg = trim(substr($value,8), '"');
+                            continue;
+                        }
+                        if ( substr($value,0,7) == 'odt_fo=' )
+                        {
+                            $odt_fo = trim(substr($value,8), '"');
+                            continue;
+                        }
+                        if ( strpos($value, '_round') !== false )
+                        {
+                            $round=true;
+                            continue;
+                        }
+                        if ( strpos($value, '_left') !== false )
+                        {
+                            $horiz_pos='left';
+                            continue;
+                        }
+                        if ( strpos($value, '_center') !== false )
+                        {
+                            $horiz_pos='center';
+                            continue;
+                        }
+                        if ( strpos($value, '_right') !== false )
+                        {
+                            $horiz_pos='right';
+                            continue;
+                        }
+                        if ( substr($value,0,8) == 'odt_pic=' )
+                        {
+                            $picture = trim(substr($value,9), '"');
+                            continue;
+                        }
+                    }                
+
+                    if ( $this->odt_type == 'container' || $this->odt_type == 'mark' ) {
+                        $this->_odtContainerOpen ($renderer, $odt_style, $picture, $width, $horiz_pos, $odt_bg, $odt_fo, $round);
+                    }
+                    if ( $this->odt_type == 'column' ) {
+                        // FIXME columns could be implemented using tables.
+                        //       But actually the parser does not know what the first
+                        //       and last columns are. As long as this info is missing,
+                        //       a table can't be used because it needs a closing tag.
+                        //$this->_odtColumnOpen ($renderer, $odt_bg, $odt_fo);
+                    }
+                    break;
+
+                case DOKU_LEXER_EXIT:
+                    if ( $this->odt_ignore == true ) {
+                        return false;
+                    }
+                    if ( $this->odt_type == 'container' || $this->odt_type == 'mark' ) {
+                        $this->_odtContainerClose ($renderer);
+                    }
+                    if ( $this->odt_type == 'column' ) {
+                        // FIXME columns could be implemented using tables.
+                        //       But actually the parser does not know what the first
+                        //       and last columns are. As long as this info is missing,
+                        //       a table can't be used because it needs a closing tag.
+                        //$this->_odtColumnClose ($renderer);
+                    }
+                    break;
+            }
+            return true;
+        }
         return false;
     }
 
+    function _odtContainerOpen (Doku_Renderer &$renderer, $odt_style, $picture, $width, $horiz_pos, $odt_bg, $odt_fo, $round) {
+        if ( $picture != NULL )
+        {
+            $picture=DOKU_PLUGIN.'wrap/images/note/48/'.$picture;
+            $pic_link=$renderer->_odtAddImageAsFileOnly($picture);
+            list($pic_width, $pic_height) = $renderer->_odtGetImageSize($picture);
+            $min_height = trim($pic_height, 'cm');
+            $margin_left = '70';
+        }
+        else
+        {
+            $min_height = 1;
+            $margin_left = '10';
+        }
+        $width_abs = ($renderer->_getPageWidth() * $width)/100;
 
+        // Add our styles.
+        $style_name='pluginwrap_DIV'.$odt_style.($width%100).$horiz_pos.$margin_left.trim($odt_bg,'#').trim($odt_fo,'#');
+        $renderer->autostyles[$style_name] =
+         '<style:style style:name="'.$style_name.'_text_frame" style:family="graphic">
+             <style:graphic-properties svg:stroke-color="'.$odt_bg.'"
+                 draw:fill="solid" draw:fill-color="'.$odt_bg.'"
+                 draw:textarea-horizontal-align="left"
+                 draw:textarea-vertical-align="center"
+                 style:horizontal-pos="'.$horiz_pos.'"
+                 fo:padding-top="0.5cm" fo:padding-bottom="0.5cm"
+                 fo:min-height="'.$min_height.'cm"
+                 style:rel-width="'.$width.'%"
+                 style:wrap="none"/>
+         </style:style>
+         <style:style style:name="'.$style_name.'_image_frame" style:family="graphic">
+             <style:graphic-properties svg:stroke-color="'.$odt_bg.'"
+                 draw:fill="none" draw:fill-color="'.$odt_bg.'"
+                 draw:textarea-horizontal-align="left"
+                 draw:textarea-vertical-align="center"
+                 style:wrap="none"/>
+         </style:style>
+         <style:style style:name="'.$style_name.'_text_box" style:family="paragraph">
+             <style:text-properties fo:color="'.$odt_fo.'"/>
+             <style:paragraph-properties
+              fo:margin-left="'.$margin_left.'pt" fo:margin-right="10pt" fo:text-indent="0cm"/>
+         </style:style>';
+
+        // Group the frame so that they are stacked one on each other.
+        $renderer->doc .= '<text:p>';
+        $renderer->doc .= '<draw:g>';
+
+        // Draw a frame with the image in it, if required.
+        // FIXME: the image will not be centered vertically.
+        //        This could be achiebed by using a table but then
+        //        it is not possible to have round corners (...as far as I know).
+        if ( $picture != NULL )
+        {
+            $renderer->doc .= '<draw:frame draw:style-name="'.$style_name.'_image_frame" draw:name="Bild1"
+                                text:anchor-type="paragraph"
+                                svg:x="0.5cm" svg:y="0.5cm"
+                                svg:width="'.$pic_width.'" svg:height="'.$pic_height.'"
+                                draw:z-index="1">
+                               <draw:image xlink:href="'.$pic_link.'"
+                                xlink:type="simple" xlink:show="embed" xlink:actuate="onLoad"/>
+                                </draw:frame>';
+        }
+
+        // Draw a frame with a text box in it. the text box will be left opened
+        // to grow with the content (requires fo:min-height in $style_name).
+        $renderer->doc .= '<draw:frame draw:style-name="'.$style_name.'_text_frame" draw:name="Bild1"
+                            text:anchor-type="paragraph"
+                            svg:x="0" svg:y="0"
+                            svg:width="'.$width_abs.'cm" svg:height="10cm" ';
+        $renderer->doc .= 'draw:z-index="0">';
+        $renderer->doc .= '<draw:text-box ';
+
+        // If required use round corners.
+        if ( $round == true )
+            $renderer->doc .= 'draw:corner-radius="0.5cm" ';
+
+        $renderer->doc .= '>';
+        $renderer->p_open($style_name.'_text_box');
+    }
+
+    function _odtContainerClose (Doku_Renderer &$renderer) {
+        $renderer->p_close();
+        $renderer->doc .= '</draw:text-box></draw:frame>';
+        $renderer->doc .= '</draw:g>';
+        $renderer->doc .= '</text:p>';
+    }
+
+    function _odtVersionToOld (Doku_Renderer &$renderer) {
+        $info=$renderer->getInfo();
+        $date = explode('-', $info['date']);
+        if ( $date [0] < 2014 )
+            return true;
+        if ( $date [0] == 2014 && $date [1] < 10 )
+            return true;
+        if ( $date [0] == 2014 && $date [1] == 10 && $date [2] < 4 )
+            return true;
+        return false;
+    }
 }
 

--- a/syntax/div.php
+++ b/syntax/div.php
@@ -132,6 +132,7 @@ class syntax_plugin_wrap_div extends DokuWiki_Syntax_Plugin {
                     $odt_style='NOT FOUND!!!';
                     $odt_bg='#FFFFFF';
                     $odt_fo='#000000';
+                    $odt_display=NULL;
                     $picture=NULL;
                     $class=NULL;
                     $this->odt_type=NULL;
@@ -178,6 +179,11 @@ class syntax_plugin_wrap_div extends DokuWiki_Syntax_Plugin {
                             $horiz_pos = trim(substr($value,11), '"');
                             continue;
                         }
+                        if ( substr($value,0,12) == 'odt_display=' )
+                        {
+                            $odt_display = trim(substr($value,13), '"');
+                            continue;
+                        }
                         if ( substr($value,0,8) == 'odt_pic=' )
                         {
                             $picture = trim(substr($value,9), '"');
@@ -186,7 +192,7 @@ class syntax_plugin_wrap_div extends DokuWiki_Syntax_Plugin {
                     }                
 
                     if ( $this->odt_type == 'container' || $this->odt_type == 'mark' ) {
-                        $this->_odtContainerOpen ($renderer, $odt_style, $picture, $width, $horiz_pos, $odt_bg, $odt_fo, $round);
+                        $this->_odtContainerOpen ($renderer, $odt_style, $picture, $width, $horiz_pos, $odt_bg, $odt_fo, $round, $odt_display);
                     }
                     if ( $this->odt_type == 'column' ) {
                         // FIXME columns could be implemented using tables.
@@ -218,7 +224,7 @@ class syntax_plugin_wrap_div extends DokuWiki_Syntax_Plugin {
         return false;
     }
 
-    function _odtContainerOpen (Doku_Renderer &$renderer, $odt_style, $picture, $width, $horiz_pos, $odt_bg, $odt_fo, $round) {
+    function _odtContainerOpen (Doku_Renderer &$renderer, $odt_style, $picture, $width, $horiz_pos, $odt_bg, $odt_fo, $round, $display) {
         if ( $picture != NULL )
         {
             $picture=DOKU_PLUGIN.'wrap/images/note/48/'.$picture;
@@ -263,7 +269,11 @@ class syntax_plugin_wrap_div extends DokuWiki_Syntax_Plugin {
 
         // Group the frame so that they are stacked one on each other.
         $renderer->doc .= '<text:p>';
-        $renderer->doc .= '<draw:g>';
+        if ( $display == NULL ) {
+            $renderer->doc .= '<draw:g>';
+        } else {
+            $renderer->doc .= '<draw:g draw:display="' . $display . '">';
+        }
 
         // Draw a frame with the image in it, if required.
         // FIXME: the image will not be centered vertically.

--- a/syntax/div.php
+++ b/syntax/div.php
@@ -173,19 +173,9 @@ class syntax_plugin_wrap_div extends DokuWiki_Syntax_Plugin {
                             $round=true;
                             continue;
                         }
-                        if ( strpos($value, '_left') !== false )
+                        if ( substr($value,0,10) == 'odt_align=' )
                         {
-                            $horiz_pos='left';
-                            continue;
-                        }
-                        if ( strpos($value, '_center') !== false )
-                        {
-                            $horiz_pos='center';
-                            continue;
-                        }
-                        if ( strpos($value, '_right') !== false )
-                        {
-                            $horiz_pos='right';
+                            $horiz_pos = trim(substr($value,11), '"');
                             continue;
                         }
                         if ( substr($value,0,8) == 'odt_pic=' )

--- a/syntax/div.php
+++ b/syntax/div.php
@@ -168,9 +168,9 @@ class syntax_plugin_wrap_div extends DokuWiki_Syntax_Plugin {
                             $odt_fo = trim(substr($value,8), '"');
                             continue;
                         }
-                        if ( strpos($value, '_round') !== false )
+                        if ( substr($value,0,10) == 'odt_round=' )
                         {
-                            $round=true;
+                            $round = trim(substr($value,11), '"');
                             continue;
                         }
                         if ( substr($value,0,10) == 'odt_align=' )

--- a/syntax/span.php
+++ b/syntax/span.php
@@ -15,6 +15,7 @@ class syntax_plugin_wrap_span extends DokuWiki_Syntax_Plugin {
 
     protected $entry_pattern = '<span.*?>(?=.*?</span>)';
     protected $exit_pattern  = '</span>';
+    protected $odt_fo_style;
 
     function getType(){ return 'formatting';}
     function getAllowedTypes() { return array('formatting', 'substition', 'disabled'); }
@@ -76,6 +77,91 @@ class syntax_plugin_wrap_span extends DokuWiki_Syntax_Plugin {
 
                 case DOKU_LEXER_EXIT:
                     $renderer->doc .= "</span>";
+                    break;
+            }
+            return true;
+        }
+        if($mode == 'odt'){
+            switch ($state) {
+                case DOKU_LEXER_ENTER:
+                    // Get attributes.
+                    $wrap =& plugin_load('helper', 'wrap');
+                    $attr = $wrap->buildAttributes($data, 'plugin_wrap',$mode);
+
+                    // Parse attributes.
+                    $token = explode(' ', $attr);
+                    $odt_style='NOT FOUND!!!';
+                    $odt_bg='#FFFFFF';
+                    $odt_fo='#000000';
+                    $class=NULL;
+                    $this->odt_fo_style=NULL;
+                    foreach ($token as $i => $value) {
+                        if ( substr($value,0,6) == 'class=' )
+                        {
+                            $class = trim(substr($value,7), '"');
+                            continue;
+                        }
+                        if ( substr($value,0,10) == 'odt_style=' )
+                        {
+                            $odt_style = trim(substr($value,10), '"');
+                            continue;
+                        }
+                        if ( substr($value,0,7) == 'odt_bg=' )
+                        {
+                            $odt_bg = trim(substr($value,8), '"');
+                            continue;
+                        }
+                        if ( substr($value,0,7) == 'odt_fo=' )
+                        {
+                            $odt_fo = trim(substr($value,8), '"');
+                            continue;
+                        }
+                        if ( substr($value,0,12) == 'odt_fo_style' )
+                        {
+                            $this->odt_fo_style = trim(substr($value,13), '"');
+                            continue;
+                        }
+                    }                
+
+                    // Add our styles.
+                    $style_name='pluginwrap_SPAN'.$odt_style.$margin_left.trim($odt_bg,'#').trim($odt_fo,'#');
+                    $renderer->autostyles[$style_name] =
+                    '<style:style style:name="'.$style_name.'_text_box" style:family="text">
+                         <style:text-properties fo:color="'.$odt_fo.'" fo:background-color="'.$odt_bg.'"/>
+                         <style:paragraph-properties
+                          fo:margin-left="'.$margin_left.'pt" fo:margin-right="0pt" fo:text-indent="0cm"/>
+                     </style:style>';
+
+                    // FIXME: I did not find a way to place a small image between the text and
+                    //        letting the text flow normal around it as if like the picture is just a letter.
+                    // So we not use an image and use a simple text span to color the text with the wanted
+                    // font and background color.
+                    $renderer->doc .= '<text:span text:style-name="'.$style_name.'_text_box">';
+
+                    // If a font style was found then set a nested span.
+                    // FIXME: allow a list of font styles e.g. 'odt_fo_style="strong underline"'
+                    if ( $this->odt_fo_style != NULL ) {
+                        if ( $this->odt_fo_style == 'strong' ) {
+                            $renderer->strong_open ();
+                        }
+                        if ( $this->odt_fo_style == 'subscript' ) {
+                            $renderer->subscript_open ();
+                        }
+                    }
+                    break;
+
+                case DOKU_LEXER_EXIT:
+                    // If a font style was found then close the nested span.
+                    if ( $this->odt_fo_style != NULL ) {
+                        if ( $this->odt_fo_style == 'strong' ) {
+                            $renderer->strong_close ();
+                        }
+                        if ( $this->odt_fo_style == 'subscript' ) {
+                            $renderer->subscript_close ();
+                        }
+                    }
+
+                    $renderer->doc .= '</text:span>';
                     break;
             }
             return true;


### PR DESCRIPTION
Implemented partial support for ODT export:

+ Container:
  + Supported:
    + Colors match CSS
    + Resize in height if content gets to big
    + Picture is present in ODT also
    - Picture is not vertically centered
    - Picture is re-sized if the box is re-sized e.g. in OpenOffice Writer
+ Spans:
  + Supported:
    + Colors match CSS
    + Styles match CSS (e.g. subscript, emphasis)
    - Small picture is missing
    - Alignment and width are ignored
- The rest is not supported right now

Columns are currently not supported. The reason is the missing start and end "markers" of the first and last column. I think it could best be implemented using a table but a table has an opening and closing tag in ODT format. But the syntax doesn't tell me what the last "<WRAP column>...</WRAP column>" pair is.
