### PR TITLE
Added ODT support for spans and containers (divs).

### DIFF
--- a/syntax/div.php
+++ b/syntax/div.php
@@ -166,6 +166,11 @@ class syntax_plugin_wrap_div extends DokuWiki_Syntax_Plugin {
                         }
                     }
 
+                    $is_pagebreak = false;
+                    if ( strpos ($class, 'wrap_pagebreak') !== false ) {
+                        $is_pagebreak = true;
+                    }
+
                     // Is there support for ODT?
                     if ( $is_box === true || $columns > 0 || $is_paragraph === true) {
                         // Yes, import CSS data
@@ -189,6 +194,9 @@ class syntax_plugin_wrap_div extends DokuWiki_Syntax_Plugin {
                                 $this->renderODTOpenParagraph ($renderer, $class, $style);
                                 array_push ($type_stack, 'p');
                             } else {
+                                if ( $is_pagebreak === true ) {
+                                    $renderer->pagebreak ();
+                                } // No else here --> pagebreak has got no closing tag!
                                 array_push ($type_stack, 'other');
                             }
                         }

--- a/syntax/span.php
+++ b/syntax/span.php
@@ -40,7 +40,7 @@ class syntax_plugin_wrap_span extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, Doku_Handler $handler){
+    function handle($match, $state, $pos, Doku_Handler &$handler){
         switch ($state) {
             case DOKU_LEXER_ENTER:
                 $data = strtolower(trim(substr($match,strpos($match,' '),-1)));
@@ -60,7 +60,7 @@ class syntax_plugin_wrap_span extends DokuWiki_Syntax_Plugin {
     /**
      * Create output
      */
-    function render($mode, Doku_Renderer $renderer, $indata) {
+    function render($mode, Doku_Renderer &$renderer, $indata) {
 
         if (empty($indata)) return false;
         list($state, $data) = $indata;
@@ -101,12 +101,18 @@ class syntax_plugin_wrap_span extends DokuWiki_Syntax_Plugin {
                         self::$import->loadReplacements(DOKU_INC.DOKU_TPL.'style.ini');
                     }
 
-                    $renderer->_odtSpanOpenUseCSS (self::$import, $class, DOKU_PLUGIN.'wrap/');
+                    if ( self::$import != NULL && 
+                         method_exists ($renderer, '_odtSpanOpenUseCSS') === true ) {
+                        $renderer->_odtSpanOpenUseCSS (self::$import, $class, DOKU_PLUGIN.'wrap/');
+                    }
                     break;
 
                 case DOKU_LEXER_EXIT:
                     // Close the span.
-                    $renderer->_odtSpanClose();
+                    if ( self::$import != NULL && 
+                         method_exists ($renderer, '_odtSpanClose') === true ) {
+                        $renderer->_odtSpanClose();
+                    }
                     break;
             }
             return true;


### PR DESCRIPTION
Here is a simple implementation of ODT support for spans and containers (divs).

As you possibly noticed I did write a patch for ODT support before but that was very ugly. All the ODT knowledge was included in the wrap plugin itself. Including ugly arrays to keep the style information.

Know that I wrote a little CSS import helper class for the ODT plugin the code looks much nicer now.

Of course it is far from perfect. One reason is simply the differences between XHTML and the ODT format.

But maybe you like it enough to merge it. This would be great, then I don't need to keep my own branch.