### PR TITLE
added 6-digit hex codes for backgroung color

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -63,6 +63,13 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
                     if ($classIsInList) continue;
                 }
             }
+            
+            //get 6-digit hex color code to interpret that as background color
+            if (preg_match('/[0-9A-F][0-9A-F][0-9A-F][0-9A-F][0-9A-F][0-9A-F]/',$token)) {
+                $attr['bgcolor'] = $token;
+                continue;
+            }
+            
             $prefix = in_array($token, $noPrefix) ? '' : 'wrap_';
             $attr['class'] = (isset($attr['class']) ? $attr['class'].' ' : '').$prefix.$token;
         }
@@ -93,13 +100,18 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
             elseif($addClass)  $out .= ' class="'.$addClass.'"';
             if($attr['id'])    $out .= ' id="'.hsc($attr['id']).'"';
             // width on spans normally doesn't make much sense, but in the case of floating elements it could be used
-            if($attr['width']) {
-                if (strpos($attr['width'],'%') !== false) {
-                    $out .= ' style="width: '.hsc($attr['width']).';"';
-                } else {
-                    // anything but % should be 100% when the screen gets smaller
-                    $out .= ' style="width: '.hsc($attr['width']).'; max-width: 100%;"';
+            if($attr['width'] || $attr['bgcolor']) {
+                $out .= ' style="';
+                if($attr['width']) {
+                    if (strpos($attr['width'],'%') !== false) {
+                        $out .= 'width: '.hsc($attr['width']).';';
+                    } else {
+                        // anything but % should be 100% when the screen gets smaller
+                        $out .= 'width: '.hsc($attr['width']).'; max-width: 100%;';
+                    }
                 }
+                if($attr['bgcolor'])    $out .= 'background-color: #"'.hsc($attr['bgcolor']).';';
+                $out .= '"';
             }
             // only write lang if it's a language in lang2dir.conf
             if($attr['dir'])   $out .= ' lang="'.$attr['lang'].'" xml:lang="'.$attr['lang'].'" dir="'.$attr['dir'].'"';

--- a/helper.php
+++ b/helper.php
@@ -54,7 +54,7 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
             //restrict token (class names) characters to prevent any malicious data
             if (preg_match('/[^A-Za-z0-9_-]/',$token)) continue;
             if ($restrictedClasses) {
-                $classIsInList = in_array(trim($token), $restrictedClasses);
+                $classIsInList = in_array(strtolower(trim($token)), $restrictedClasses);
                 // either allow only certain classes
                 if ($restrictionType) {
                     if (!$classIsInList) continue;
@@ -70,6 +70,7 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
                 continue;
             }
             
+            $token = strtolower($token);
             $prefix = in_array($token, $noPrefix) ? '' : 'wrap_';
             $attr['class'] = (isset($attr['class']) ? $attr['class'].' ' : '').$prefix.$token;
         }

--- a/helper.php
+++ b/helper.php
@@ -65,7 +65,7 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
             }
             
             //get 6-digit hex color code to interpret that as background color
-            if (preg_match('/[0-9A-F][0-9A-F][0-9A-F][0-9A-F][0-9A-F][0-9A-F]/',$token)) {
+            if (preg_match('/[\dA-F]{6}$/A',$token)) {
                 $attr['bgcolor'] = $token;
                 continue;
             }
@@ -110,7 +110,7 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
                         $out .= 'width: '.hsc($attr['width']).'; max-width: 100%;';
                     }
                 }
-                if($attr['bgcolor'])    $out .= 'background-color: #"'.hsc($attr['bgcolor']).';';
+                if($attr['bgcolor'])    $out .= 'background-color: #'.hsc($attr['bgcolor']).';';
                 $out .= '"';
             }
             // only write lang if it's a language in lang2dir.conf

--- a/syntax/div.php
+++ b/syntax/div.php
@@ -44,7 +44,7 @@ class syntax_plugin_wrap_div extends DokuWiki_Syntax_Plugin {
         global $conf;
         switch ($state) {
             case DOKU_LEXER_ENTER:
-                $data = strtolower(trim(substr($match,strpos($match,' '),-1)));
+                $data = trim(substr($match,strpos($match,' '),-1));
                 return array($state, $data);
 
             case DOKU_LEXER_UNMATCHED:

--- a/syntax/span.php
+++ b/syntax/span.php
@@ -43,7 +43,7 @@ class syntax_plugin_wrap_span extends DokuWiki_Syntax_Plugin {
     function handle($match, $state, $pos, Doku_Handler $handler){
         switch ($state) {
             case DOKU_LEXER_ENTER:
-                $data = strtolower(trim(substr($match,strpos($match,' '),-1)));
+                $data = trim(substr($match,strpos($match,' '),-1));
                 return array($state, $data);
 
             case DOKU_LEXER_UNMATCHED :


### PR DESCRIPTION
The most missing feature of Wrap plugin for me is the ability to set the background color in a form of an arbitrary hex code.
So I added this check: if a token is a 6-digit hex code, written in capital letters, e.g. FF0077, then it's interpreted as a backgroung color for the WRAP'ped element, by adding "backgroung-color: #xxxxxx" to the element's style.
(I also had to move strtolower() from div.php and span.php to helper.php, to be able to distinguish uppercase hex codes).