### PR TITLE
Adjustment for ODT redesign branch and minor improvements:

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -483,23 +483,14 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
         if ( $this->column_count == 1 ) {
             // If this is the first column opened since the group was opened
             // then we have to open the table and a (single) row first.
-            $column_width = $properties ['width'];
             $properties ['width'] = '100%';
             $renderer->_odtTableOpenUseProperties($properties);
             $renderer->_odtTableRowOpenUseProperties($properties);
-            $properties ['width'] = $column_width;
-        }
-
-        // Convert rel-width to absolute width.
-        // The width in percentage works strange in LibreOffice, this is a workaround.
-        $length = strlen ($properties ['width']);
-        if ( $length > 0 && $properties ['width'] [$length-1] == '%' ) {
-            $properties ['width'] = trim ($properties ['width'], '%');
-            $properties ['width'] = $renderer->_getAbsWidthMindMargins ($properties ['width']).'cm';
         }
 
         // We did not specify any max column value when we opened the table.
         // So we have to tell the renderer to add a column just now.
+        unset($properties ['width']);
         $renderer->_odtTableAddColumnUseProperties($properties);
 
         // Open the cell.

--- a/helper.php
+++ b/helper.php
@@ -121,8 +121,8 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
      * (get Attributes, select ODT element that fits, render it, return element name)
      */
     function renderODTElementOpen($renderer, $HTMLelement, $data) {
-
         $attr = $this->getAttributes($data);
+        $attr_string = $this->buildAttributes($data);
         $classes = explode (' ', $attr['class']);
 
         // Get language
@@ -172,28 +172,35 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
         // Call corresponding functions for current wrap class
         if ( $HTMLelement == 'span' ) {
             if ( $is_indent === false && $is_outdent === false ) {
-                $this->renderODTOpenSpan ($renderer, $attr ['class'], $style, $language);
+                $this->renderODTOpenSpan ($renderer, $attr ['class'], $style, $language, $attr_string);
                 return 'span';
             } else {
-                $this->renderODTOpenParagraph ($renderer, $attr ['class'], $style, $language, $is_indent, $is_outdent, true);
+                $this->renderODTOpenParagraph ($renderer, $attr ['class'], $style, $attr ['dir'], $language, $is_indent, $is_outdent, true, $attr_string);
                 return 'paragraph';
             }
         } else if ( $HTMLelement == 'div' ) {
             if ( $is_box === true ) {
-                $this->renderODTOpenBox ($renderer, $attr ['class'], $style);
+                $wrap = $this->loadHelper('wrap');
+                $fullattr = $wrap->buildAttributes($data, 'plugin_wrap');
+
+                if ( method_exists ($renderer, 'getODTPropertiesFromElement') === false ) {
+                    $this->renderODTOpenBox ($renderer, $attr ['class'], $style, $fullattr);
+                } else {
+                    $this->renderODTOpenTable ($renderer, $attr, $style,  $attr_string);
+                }
                 return 'box';
             } else if ( $columns > 0 ) {
                 $this->renderODTOpenColumns ($renderer, $attr ['class'], $style);
                 return 'multicolumn';
             } else if ( $is_paragraph === true || $is_indent === true || $is_outdent === true ) {
-                $this->renderODTOpenParagraph ($renderer, $attr ['class'], $style, $language, $is_indent, $is_outdent, false);
+                $this->renderODTOpenParagraph ($renderer, $attr ['class'], $style, $attr ['dir'], $language, $is_indent, $is_outdent, false, $attr_string);
                 return 'paragraph';
             } else if ( $is_pagebreak === true ) {
                 $renderer->pagebreak ();
                 // Pagebreak hasn't got a closing stack so we return/push 'other' on the stack
                 return 'other';
             } else if ( $is_column === true ) {
-                $this->renderODTOpenColumn ($renderer, $attr ['class'], $style);
+                $this->renderODTOpenColumn ($renderer, $attr ['class'], $style, $attr_string);
                 return 'column';
             } else if ( $is_group === true ) {
                 $this->renderODTOpenGroup ($renderer, $attr ['class'], $style);
@@ -209,7 +216,11 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
     function renderODTElementClose($renderer, $element) {
         switch ($element) {
             case 'box':
-                $this->renderODTCloseBox ($renderer);
+                if ( method_exists ($renderer, 'getODTPropertiesFromElement') === false ) {
+                    $this->renderODTCloseBox ($renderer);
+                } else {
+                    $this->renderODTCloseTable ($renderer);
+                }
             break;
             case 'multicolumn':
                 $this->renderODTCloseColumns($renderer);
@@ -230,7 +241,7 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
         }
     }
 
-    function renderODTOpenBox ($renderer, $class, $style) {
+    function renderODTOpenBox ($renderer, $class, $style, $fullattr) {
         $properties = array ();
 
         if ( method_exists ($renderer, 'getODTProperties') === false ) {
@@ -298,24 +309,42 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
         $renderer->_odtCloseMultiColumnFrame();
     }
 
-    function renderODTOpenParagraph ($renderer, $class, $style, $language, $is_indent, $is_outdent, $indent_first) {
+    function renderODTOpenParagraph ($renderer, $class, $style, $dir, $language, $is_indent, $is_outdent, $indent_first, $attr=NULL) {
         $properties = array ();
 
-        if ( method_exists ($renderer, 'getODTProperties') === false ) {
-            // Function is not supported by installed ODT plugin version, return.
+        if ( method_exists ($renderer, 'getODTPropertiesFromElement') === true ) {
+            // Get CSS properties for ODT export.
+            // Set parameter $inherit=false to prevent changiung the font-size and family!
+            $renderer->getODTPropertiesNew ($properties, 'p', $attr, NULL, false);
+        } else if ( method_exists ($renderer, 'getODTProperties') === true ) {
+            // Get CSS properties for ODT export (deprecated version).
+            $renderer->getODTProperties ($properties, 'p', $class, $style);
+
+            if ( empty($properties ['background-image']) === false ) {
+                $properties ['background-image'] =
+                    $renderer->replaceURLPrefix ($properties ['background-image'], DOKU_INC);
+            }
+        } else {
+            // To old ODT plugin version.
             return;
         }
 
-        // Get CSS properties for ODT export.
-        $renderer->getODTProperties ($properties, 'p', $class, $style);
-
-        if ( empty($properties ['background-image']) === false ) {
-            $properties ['background-image'] =
-                $renderer->replaceURLPrefix ($properties ['background-image'], DOKU_INC);
+        if ( empty($properties ['text-align']) )
+        {
+            if ($dir == 'ltr') {
+                $properties ['text-align'] = 'left';
+                $properties ['writing-mode'] = 'lr';
+            }
+            if ($dir == 'rtl') {
+                $properties ['text-align'] = 'right';
+                $properties ['writing-mode'] = 'rl';
+            }
         }
 
+        $name = '';
         if ( empty($language) === false ) {
             $properties ['lang'] = $language;
+            $name .= 'Language: '.$language;
         }
 
         if ( $indent_first === true ) {
@@ -325,12 +354,14 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
                 // See all.css
                 $properties ['text-indent'] = $properties ['padding-left'];
                 $properties ['padding-left'] = 0;
+                $name .= 'Indent first';
             }
             if ( $is_outdent === true ) {
                 // FIXME: Has to be adjusted if text (RTL, LTR) direction will be supported.
                 // See all.css
                 $properties ['text-indent'] = $properties ['margin-left'];
                 $properties ['margin-left'] = 0;
+                $name .= 'Outdent first';
             }
         } else {
             // Eventually indent or outdent the whole paragraph...
@@ -339,16 +370,45 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
                 // See all.css
                 $properties ['margin-left'] = $properties ['padding-left'];
                 $properties ['padding-left'] = 0;
+                $name .= 'Indent';
             }
             if ( $is_outdent === true ) {
                 // Nothing to change: keep left margin property.
                 // FIXME: Has to be adjusted if text (RTL, LTR) direction will be supported.
                 // See all.css
+                $name .= 'Outdent';
             }
         }
 
         $renderer->p_close();
-        $renderer->_odtParagraphOpenUseProperties($properties);
+        if ( method_exists ($renderer, 'createParagraphStyle') === false ) {
+            // Older ODT plugin version.
+            $renderer->_odtParagraphOpenUseProperties($properties);
+        } else {
+            // Newer version create our own common styles.
+            
+            // Create parent style to group the others beneath it        
+            if (!$renderer->styleExists('Plugin_Wrap_Paragraphs')) {
+                $parent_properties = array();
+                $parent_properties ['style-parent'] = NULL;
+                $parent_properties ['style-class'] = 'Plugin Wrap Paragraphs';
+                $parent_properties ['style-name'] = 'Plugin_Wrap_Paragraphs';
+                $parent_properties ['style-display-name'] = 'Plugin Wrap';
+                $renderer->createParagraphStyle($parent_properties);
+            }
+
+            $name .= $this->getODTCommonStyleName($class);
+            $style_name = 'Plugin_Wrap_Paragraph_'.$name;
+            if (!$renderer->styleExists($style_name)) {
+                $properties ['style-parent'] = 'Plugin_Wrap_Paragraphs';
+                $properties ['style-class'] = NULL;
+                $properties ['style-name'] = $style_name;
+                $properties ['style-display-name'] = $name;
+                $renderer->createParagraphStyle($properties);
+            }
+
+            $renderer->p_open($style_name);
+        }
     }
 
     function renderODTCloseParagraph ($renderer) {
@@ -359,17 +419,19 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
         $renderer->p_close();
     }
 
-    function renderODTOpenColumn ($renderer, $class, $style) {
+    function renderODTOpenColumn ($renderer, $class, $style, $attr) {
         $properties = array ();
 
-        if ( method_exists ($renderer, 'getODTProperties') === false ) {
-            // Function is not supported by installed ODT plugin version, return.
+        if ( method_exists ($renderer, 'getODTPropertiesFromElement') === true ) {
+            // Get CSS properties for ODT export.
+            $renderer->getODTPropertiesNew ($properties, 'div', $attr);
+        } else if ( method_exists ($renderer, 'getODTProperties') === true ) {
+            // Get CSS properties for ODT export (deprecated version).
+            $renderer->getODTProperties ($properties, NULL, $class, $style);
+        } else {
+            // To old ODT plugin version.
             return;
         }
-
-        // Get CSS properties for ODT export.
-        $renderer->getODTProperties ($properties, NULL, $class, $style);
-
 
         // Frames/Textboxes still have some issues with formatting (at least in LibreOffice)
         // So as a workaround we implement columns as a table.
@@ -456,27 +518,76 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
         $this->column_count = 0;
     }
 
-    function renderODTOpenSpan ($renderer, $class, $style, $language) {
+    function renderODTOpenSpan ($renderer, $class, $style, $language, $attr) {
         $properties = array ();
 
-        if ( method_exists ($renderer, 'getODTProperties') === false ) {
-            // Function is not supported by installed ODT plugin version, return.
+        if ( method_exists ($renderer, 'getODTPropertiesFromElement') === true ) {
+            // Get CSS properties for ODT export.
+            // Set parameter $inherit=false to prevent changiung the font-size and family!
+            $renderer->getODTPropertiesNew ($properties, 'span', $attr, NULL, false);
+        } else if ( method_exists ($renderer, 'getODTProperties') === true ) {
+            // Get CSS properties for ODT export (deprecated version).
+            $renderer->getODTProperties ($properties, 'span', $class, $style);
+
+            if ( empty($properties ['background-image']) === false ) {
+                $properties ['background-image'] =
+                    $renderer->replaceURLPrefix ($properties ['background-image'], DOKU_INC);
+            }
+        } else {
+            // To old ODT plugin version.
             return;
         }
 
-        // Get CSS properties for ODT export.
-        $renderer->getODTProperties ($properties, 'span', $class, $style);
-
-        if ( empty($properties ['background-image']) === false ) {
-            $properties ['background-image'] =
-                $renderer->replaceURLPrefix ($properties ['background-image'], DOKU_INC);
-        }
-
+        $name = '';
         if ( empty($language) === false ) {
             $properties ['lang'] = $language;
+            $name .= 'Language: '.$language;
         }
 
-        $renderer->_odtSpanOpenUseProperties($properties);
+        if ( method_exists ($renderer, 'getODTPropertiesFromElement') === false ) {
+            // Older ODT plugin version.
+            $renderer->_odtSpanOpenUseProperties($properties);
+        } else {
+            // Newer version create our own common styles.
+            $properties ['font-size'] = NULL;
+            
+            // Create parent style to group the others beneath it        
+            if (!$renderer->styleExists('Plugin_Wrap_Spans')) {
+                $parent_properties = array();
+                $parent_properties ['style-parent'] = NULL;
+                $parent_properties ['style-class'] = 'Plugin Wrap Spans';
+                $parent_properties ['style-name'] = 'Plugin_Wrap_Spans';
+                $parent_properties ['style-display-name'] = 'Plugin Wrap';
+                $renderer->createTextStyle($parent_properties);
+            }
+
+            $name .= $this->getODTCommonStyleName($class);
+            $style_name = 'Plugin_Wrap_Span_'.$name;
+            if (!$renderer->styleExists($style_name)) {
+                $properties ['style-parent'] = 'Plugin_Wrap_Spans';
+                $properties ['style-class'] = NULL;
+                $properties ['style-name'] = $style_name;
+                $properties ['style-display-name'] = $name;
+                $renderer->createTextStyle($properties);
+            }
+
+            if (!empty($properties ['background-image'])) {
+                if (method_exists ($renderer, '_odtAddImageUseProperties') === true) {
+                    $size = NULL;
+                    if (!empty($properties ['font-size'])) {
+                        $size = $properties ['font-size'];
+                        $size = $renderer->addToValue($size, '2pt');
+                    }
+                    $properties ['width'] = $size;
+                    $properties ['height'] = $size;
+                    $properties ['title'] = NULL;
+                    $renderer->_odtAddImageUseProperties ($properties ['background-image'],$properties);
+                } else {
+                    $renderer->_odtAddImage ($properties ['background-image'],NULL,NULL,NULL,NULL,NULL);
+                }
+            }
+            $renderer->_odtSpanOpen($style_name);
+        }
     }
 
     function renderODTCloseSpan ($renderer) {
@@ -485,5 +596,115 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
             return;
         }
         $renderer->_odtSpanClose();
+    }
+
+    function renderODTOpenTable ($renderer, $attr, $style, $attr_string) {
+        $class = $attr ['class'];
+        $properties = array ();
+
+        if ( method_exists ($renderer, 'getODTPropertiesFromElement') === false ) {
+            // Function is not supported by installed ODT plugin version, return.
+            return;
+        }
+
+        // Get CSS properties for ODT export.
+        $renderer->getODTPropertiesNew ($properties, 'div', $attr_string, NULL, true);
+
+        if ( empty($properties ['float']) === true ) {
+            // If the float property is not set, set it to 'left' becuase the ODT plugin
+            // would default to 'center' which is diffeent to the XHTML behaviour.
+            if ( strpos ($class, 'wrap_center') === false ) {
+                $properties ['float'] = 'left';
+            } else {
+                $properties ['float'] = 'center';
+            }
+        }
+
+        // The display property has differing usage in CSS. So we better overwrite it.
+        $properties ['display'] = 'always';
+        if ( stripos ($class, 'wrap_noprint') !== false ) {
+            $properties ['display'] = 'screen';
+        }
+        if ( stripos ($class, 'wrap_onlyprint') !== false ) {
+            $properties ['display'] = 'printer';
+        }
+                
+        $background_color = $properties ['background-color'];
+        $image = $properties ['background-image'];
+        $margin_top = $properties ['margin-top'];
+        $margin_right = $properties ['margin-right'];
+        $margin_bottom = $properties ['margin-bottom'];
+        $margin_left = $properties ['margin-left'];
+        $width = $attr ['width'];
+        
+        // Open 2x1 table if image is present
+        // otherwise only a 1x1 table
+        $properties = array();
+        $properties ['width'] = $attr ['width'];
+        $properties ['align'] = 'center';
+        $properties ['margin-top'] = $margin_top;
+        $properties ['margin-right'] = $margin_right;
+        $properties ['margin-bottom'] = $margin_bottom;
+        $properties ['margin-left'] = $margin_left;
+
+        $renderer->_odtTableOpenUseProperties($properties);
+
+        if (!empty($image)) {
+            $properties = array();
+            $properties ['width'] = '2cm';
+            $renderer->_odtTableAddColumnUseProperties($properties);
+        }
+
+        $properties = array();
+        $renderer->_odtTableAddColumnUseProperties($properties);
+
+        $renderer->tablerow_open();
+
+        if (!empty($image)) {
+            $properties = array();
+            $properties ['vertical-align'] = 'middle';
+            $properties ['text-align'] = 'center';
+            $properties ['padding'] = '0.1cm';
+            $properties ['background-color'] = $background_color;
+
+            $renderer->_odtTableCellOpenUseProperties($properties);
+            $renderer->_odtAddImage($image);
+            $renderer->tablecell_close();
+        }
+
+        $properties = array();
+        $properties ['vertical-align'] = 'middle';
+        $properties ['padding'] = '0.3cm';
+        $properties ['background-color'] = $background_color;
+        $properties ['border'] = 'none';
+        $renderer->_odtTableCellOpenUseProperties($properties);
+    }
+
+    function renderODTCloseTable ($renderer) {
+        $renderer->tablecell_close();
+        $renderer->tablerow_close();
+        $renderer->_odtTableClose();
+
+        $renderer->p_open();
+    }
+
+    protected function getODTCommonStyleName ($class_string) {
+        static $map = array (
+            'wrap_box' => 'Box', 'wrap_danger' => 'Danger', 'wrap_warning' => 'Warning',
+            'wrap_caution' => 'Caution', 'wrap_notice' => 'Notice', 'wrap_safety' => 'Safety',
+            'wrap_info' => 'Info', 'wrap_important' => 'Important', 'wrap_alert' => 'Alert',
+            'wrap_tip' => 'Tip', 'wrap_help' => 'Help', 'wrap_todo' => 'To do',
+            'wrap_download' => 'Download', 'wrap_hi' => 'Highlighted', 'wrap_spoiler' => 'Spoiler',
+            'wrap_leftalign' => 'Left aligned', 'wrap_rightalign' => 'Right aligned',
+            'wrap_centeralign' => 'Centered', 'wrap_justify' => 'Justify', 'wrap_em' => 'Emphasised',
+            'wrap_lo' => 'Less significant');
+        $classes = explode(' ', $class_string);
+        $name = '';
+        foreach ($classes as $class) {
+            if (array_key_exists($class, $map)) {
+                $name .= $map [$class];
+            }
+        }
+        return ($name);
     }
 }


### PR DESCRIPTION
- improved support for languages/text direction (ltr or rtl)
- render boxes as tables (so we lose round corners but get formating inside of the boxes)
- Paragraph and Span styles will be editable in LibreOffice after export

The Wrap plugin will be backward compatible to previous ODT plugin versions but new features will only work with the redesign branch of the ODT plugin.

With the current release of the ODT plugin everything should be as it was before except support for languages: text direction and alignment should now be set according to the language.
