### PR TITLE
allow Wildcards (?,*) to specify noPrefix and restricted class names

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -40,10 +40,11 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
         //   each item may contain wildcard (*, ?)
         $noPrefix = ($this->getConf('noPrefix')) ? $pattern($this->getConf('noPrefix')) : '';
 
-        $restrictedClasses = $this->getConf('restrictedClasses');
-        if ($restrictedClasses) {
-            $restrictedClasses = array_map('trim', explode(',', $this->getConf('restrictedClasses')));
-        }
+        // restrictedClasses : comma separated class names that should be checked
+        //   based on restriction type (whitelist or blacklist),
+        //   each item may contain wildcard (*, ?)
+        $restrictedClasses = ($this->getConf('restrictedClasses')) ?
+                            $pattern($this->getConf('restrictedClasses')) : '';
         $restrictionType = $this->getConf('restrictionType');
 
         foreach ($tokens as $token) {
@@ -70,7 +71,7 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
             //restrict token (class names) characters to prevent any malicious data
             if (preg_match('/[^A-Za-z0-9_-]/',$token)) continue;
             if ($restrictedClasses) {
-                $classIsInList = in_array(trim($token), $restrictedClasses);
+                $classIsInList = preg_match($restrictedClasses, $token);
                 // either allow only certain classes
                 if ($restrictionType) {
                     if (!$classIsInList) continue;

--- a/helper.php
+++ b/helper.php
@@ -72,13 +72,8 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
             if (preg_match('/[^A-Za-z0-9_-]/',$token)) continue;
             if ($restrictedClasses) {
                 $classIsInList = preg_match($restrictedClasses, $token);
-                // either allow only certain classes
-                if ($restrictionType) {
-                    if (!$classIsInList) continue;
-                // or disallow certain classes
-                } else {
-                    if ($classIsInList) continue;
-                }
+                // either allow only certain classes or disallow certain classes
+                if ($restrictionType xor $classIsInList) continue;
             }
             // prefix adjustment of class name
             $prefix = (preg_match($noPrefix, $token)) ? '' : 'wrap_';

--- a/helper.php
+++ b/helper.php
@@ -28,7 +28,18 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
 
         $attr = array();
         $tokens = preg_split('/\s+/', $data, 9);
-        $noPrefix = array_map('trim', explode(',', $this->getConf('noPrefix')));
+
+        // anonymous function to convert inclusive comma separated items to regex pattern
+        $pattern = function ($csv) {
+            return '/^(?:'. str_replace(['?','*',' ',','],
+                                        ['.','.*','','|'], $csv) .')$/';
+        };
+
+        // noPrefix: comma separated class names that should be excluded from
+        //   being prefixed with "wrap_",
+        //   each item may contain wildcard (*, ?)
+        $noPrefix = ($this->getConf('noPrefix')) ? $pattern($this->getConf('noPrefix')) : '';
+
         $restrictedClasses = $this->getConf('restrictedClasses');
         if ($restrictedClasses) {
             $restrictedClasses = array_map('trim', explode(',', $this->getConf('restrictedClasses')));
@@ -68,7 +79,8 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
                     if ($classIsInList) continue;
                 }
             }
-            $prefix = in_array($token, $noPrefix) ? '' : 'wrap_';
+            // prefix adjustment of class name
+            $prefix = (preg_match($noPrefix, $token)) ? '' : 'wrap_';
             $attr['class'] = (isset($attr['class']) ? $attr['class'].' ' : '').$prefix.$token;
         }
         if ($this->getConf('darkTpl')) {


### PR DESCRIPTION
I have some "wf-" prefixed classes that contains web fonts declaration. Prior to use them in WRAP boxes, I have to set each of them as noPrefix classes in the Config manager. It must be convenient if wildcards are available to specify web fonts classes like "`tabs, group, wf-*`". 

This PR will implement simple converter that builds regular expression pattern from comma separated class name list (csv), and use preg_match() instead of in_array() to check prefixing with "wrap_" for the WRAP box. The same methodology may be applicable to check restrictedClasses matching.

