### PR TITLE
feat: add pdf.less for better export with dw2pdf

### DIFF
--- a/pdf.less
+++ b/pdf.less
@@ -1,3 +1,9 @@
+
+.dokuwiki div.wrap_onlyprint {
+    display: block;
+}
+.dokuwiki span.wrap_onlyprint {
+    display: inline;
 }
 
 /*____________ pagebreak ____________*/

--- a/pdf.less
+++ b/pdf.less
@@ -1,0 +1,20 @@
+.dokuwiki .wrap_spoiler {
+    visibility: hidden;
+}
+
+/*____________ pagebreak ____________*/
+
+.dokuwiki .wrap_pagebreak {
+    page-break-after: always;
+}
+
+/*____________ avoid page break ____________*/
+/* not yet supported by most browsers */
+
+.dokuwiki .wrap_nopagebreak {
+    page-break-inside: avoid;
+}
+
+.dokuwiki .wrap_noprint {
+    display: none;
+}

--- a/pdf.less
+++ b/pdf.less
@@ -1,5 +1,3 @@
-.dokuwiki .wrap_spoiler {
-    visibility: hidden;
 }
 
 /*____________ pagebreak ____________*/


### PR DESCRIPTION
dw2pdf uses the print.css if there is no pdf.css available. It also allows the usage of the style.css for configured plugins. However, wrap's print.css removes the left margin from note boxes and causes the text to be displayed above the icon in the resulting pdf.

Adding a pdf.less fixes that problem and allows for feature changes affecting pdf only.

To work its magic, this pull request depends on the bugfix in splitbrain/dokuwiki-plugin-dw2pdf#325 .