### PR TITLE
Update .travis.yml to fix unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,18 @@
 language: php
 php:
+  - "7.2"
+  - "7.1"
+  - "7.0"
   - "5.6"
-  - "5.5"
-  - "5.4"
-  - "5.3"
 env:
   - DOKUWIKI=master
   - DOKUWIKI=stable
   - DOKUWIKI=old-stable
 before_install: wget https://raw.github.com/splitbrain/dokuwiki-travis/master/travis.sh
 install: sh travis.sh
-script: cd _test && phpunit --stderr --group plugin_wrap
+before_script:
+  - wget https://phar.phpunit.de/phpunit-5.7.phar
+  - cd _test
+script:
+  - if [ "$DOKUWIKI" = "master" ]; then phpunit --stderr --group plugin_wrap; fi
+  - if [ "$DOKUWIKI" != "master" ]; then php ../phpunit-5.7.phar --stderr --group plugin_wrap; fi


### PR DESCRIPTION
Use older PHPUnit version for older DokuWiki versions and latest PHPUnit for latest DokuWiki due to lacking backwards compatibility of PHPUnit 6. (See https://github.com/splitbrain/dokuwiki/issues/1837)
This will have to be updated when the next two DokuWiki versions will be released.

And add newer and remove old and unsupported PHP versions.