### PR TITLE
Add new type of width-based multi-columns

### DIFF
--- a/all.css
+++ b/all.css
@@ -85,7 +85,8 @@ Screen and Print Styles for the Wrap Plugin
 
 /*____________ CSS3 columns  ____________*/
 
-.dokuwiki .wrap_col2, .dokuwiki .wrap_col3, .dokuwiki .wrap_col4, .dokuwiki .wrap_col5 {
+.dokuwiki .wrap_col2, .dokuwiki .wrap_col3, .dokuwiki .wrap_col4, .dokuwiki .wrap_col5,
+.dokuwiki .wrap_colsmall, .dokuwiki .wrap_colmedium, .dokuwiki .wrap_collarge {
     -moz-column-gap: 1.5em;
     -webkit-column-gap: 1.5em;
     column-gap: 1.5em;
@@ -112,6 +113,22 @@ Screen and Print Styles for the Wrap Plugin
     -moz-column-count: 5;
     -webkit-column-count: 5;
     column-count: 5;
+}
+
+.dokuwiki .wrap_colsmall {
+    -moz-column-width: 10em;
+    -webkit-column-width: 10em;
+    column-width: 10em;
+}
+.dokuwiki .wrap_colmedium {
+    -moz-column-width: 20em;
+    -webkit-column-width: 20em;
+    column-width: 20em;
+}
+.dokuwiki .wrap_collarge {
+    -moz-column-width: 30em;
+    -webkit-column-width: 30em;
+    column-width: 30em;
 }
 
 

--- a/example.txt
+++ b/example.txt
@@ -136,8 +136,12 @@ If you need text that is bold and italic, simply use it the other way around: ''
 
 === Multi-columns ===
 
-<WRAP col3>
-For modern browsers (Firefox, Chrome and Safari, IE10+) you can use multi-columns. Just use **''%%col2%%''** for 2 columns, **''%%col3%%''** for 3 columns, **''%%col4%%''** for 4 columns and **''%%col5%%''** for 5 columns.
+<WRAP colmedium>
+Multi-columns work best in modern browsers (no IE9 and below) but should still be considered experimental as some browser behaviour is still inconsistent and buggy.
+
+Just use **''%%colsmall%%''** for small width columns, **''%%colmedium%%''** for medium width columns and **''%%collarge%%''** for large width columns.
+Or you can use **''%%col2%%''** for 2 columns, **''%%col3%%''** for 3 columns, **''%%col4%%''** for 4 columns and **''%%col5%%''** for 5 columns.
+The former type of column is determined by its width, the latter by its amount. The width-based columns are ideal for different layouts and device widths.
 
 :!: Note: Multi-columns don't make sense for spans.
 </WRAP>


### PR DESCRIPTION
As suggested in #159, this adds a new type of multi-column (`colsmall`, `colmedium` and `collarge`) which is width-based instead of amount-based. That makes them more flexible in various layouts, specifically showing more or less columns depending on viewport widths, e.g. on mobile.