### PR TITLE
use default styles in pdf.less

### DIFF
--- a/pdf.less
+++ b/pdf.less
@@ -3,9 +3,10 @@ Styles used in PDFs by the DW2PDF plugin (in addition to all.css, and
 the DW2PDF plugin also includes style.css via the 'usestyles' option)
 ********************************************************************/
 
-.dokuwiki {
-
+@import 'style.less';
 @import 'print_or_pdf.less';
+
+.dokuwiki {
 
 /*____________ only print ____________*/
 /* due to including style.css, these need to be overwritten again */

--- a/print.less
+++ b/print.less
@@ -2,9 +2,9 @@
 Print Styles for the Wrap Plugin (additional to all.css)
 ********************************************************************/
 
-.dokuwiki {
-
 @import 'print_or_pdf.less';
+
+.dokuwiki {
 
 /* boxes and notes with icons
 ********************************************************************/

--- a/print_or_pdf.less
+++ b/print_or_pdf.less
@@ -7,19 +7,19 @@ Styles shared between print.css and pdf.css
 
 /*____________ pagebreak ____________*/
 
-.wrap_pagebreak {
+.dokuwiki .wrap_pagebreak {
     page-break-after: always;
 }
 
 /*____________ avoid page break ____________*/
 /* not yet supported by most browsers */
 
-.wrap_nopagebreak {
+.dokuwiki .wrap_nopagebreak {
     page-break-inside: avoid;
 }
 
 /*____________ no print ____________*/
 
-.wrap_noprint {
+.dokuwiki .wrap_noprint {
     display: none;
 }


### PR DESCRIPTION
This allows to show the default styles in pdf documents created with
dw2pdf without having to use explicitly add wrap to the screen styles
enabled dwpw2pdf config option.

The import is place outside of the .dokuwiki selector, since style.less
already includes .dokuwiki selectors itself. For consistency the import
of print_or_pdf.less is also moved outside of the selector.