### PR TITLE
Deprecate emulated headlines

### DIFF
--- a/all.less
+++ b/all.less
@@ -15,15 +15,18 @@ Screen and Print Styles for the Wrap Plugin
 .plugin_wrap table {
     width: 100%;
 }
-/* emulate a headline */
-.plugin_wrap em strong {
+
+/* emulate a headline
+   (only with 'emulatedHeadlines' config option set)
+   @deprecated 2018-03-20 */
+.plugin_wrap.wrap__emuhead em strong {
     font-size: 130%;
     font-weight: bold;
     font-style: normal;
     display: block;
 }
 /* emulate a bigger headline with a bottom border */
-.plugin_wrap em strong em.u {
+.plugin_wrap.wrap__emuhead em strong em.u {
     font-size: 115%;
     border-bottom: 1px solid __border__;
     font-style: normal;
@@ -31,24 +34,24 @@ Screen and Print Styles for the Wrap Plugin
     display: block;
 }
 /* different bigger headline for safety notes */
-.wrap_danger em strong em.u,
-.wrap_warning em strong em.u,
-.wrap_caution em strong em.u,
-.wrap_notice em strong em.u,
-.wrap_safety em strong em.u {
+.wrap_danger.wrap__emuhead em strong em.u,
+.wrap_warning.wrap__emuhead em strong em.u,
+.wrap_caution.wrap__emuhead em strong em.u,
+.wrap_notice.wrap__emuhead em strong em.u,
+.wrap_safety.wrap__emuhead em strong em.u {
     text-transform: uppercase;
     border-bottom-width: 0;
 }
 /* change border colour of emulated headlines inside boxes to something more neutral
    (to match all the different background colours) */
-.wrap_box em strong em.u,
-.wrap_info em strong em.u,
-.wrap_important em strong em.u,
-.wrap_alert em strong em.u,
-.wrap_tip em strong em.u,
-.wrap_help em strong em.u,
-.wrap_todo em strong em.u,
-.wrap_download em strong em.u {
+.wrap_box.wrap__emuhead em strong em.u,
+.wrap_info.wrap__emuhead em strong em.u,
+.wrap_important.wrap__emuhead em strong em.u,
+.wrap_alert.wrap__emuhead em strong em.u,
+.wrap_tip.wrap__emuhead em strong em.u,
+.wrap_help.wrap__emuhead em strong em.u,
+.wrap_todo.wrap__emuhead em strong em.u,
+.wrap_download.wrap__emuhead em strong em.u {
     border-bottom-color: #999;
 }
 

--- a/conf/default.php
+++ b/conf/default.php
@@ -10,3 +10,4 @@ $conf['restrictionType'] = 0; //0= exclude restricted classes, 1=include restric
 $conf['syntaxDiv'] = 'WRAP';
 $conf['syntaxSpan'] = 'wrap';
 $conf['darkTpl'] = 0;
+$conf['emulatedHeadlines'] = 0;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -10,3 +10,4 @@ $meta['restrictionType'] = array('multichoice','_choices' => array(0,1));
 $meta['syntaxDiv'] = array('multichoice','_choices' => array('WRAP','block', 'div'));
 $meta['syntaxSpan'] = array('multichoice','_choices' => array('wrap', 'inline', 'span'));
 $meta['darkTpl'] = array('onoff');
+$meta['emulatedHeadlines'] = array('onoff');

--- a/example.txt
+++ b/example.txt
@@ -127,11 +127,11 @@ You can use the same options with spans (as each element that floats is automati
 
 All of those options will also work in the [[#boxes and notes]] wraps (see below).
 
-=== Old Emulated Headlines ===
+=== Old Emulated Headline (deprecated) ===
 
-Every ''%%//**__text like this__**//%%'' or ''%%//**like that**//%%'' will create an "emulated headline" when used within a box or a column. Now that headlines within wraps are supported, they are not needed anymore, but are still supported for backwards-compatibility.
+When the ''emulatedHeadlines'' config option is enabled, every ''%%//**__text like this__**//%%'' or ''%%//**like that**//%%'' will create an "emulated headline" within a wrap. This feature is deprecated and will be removed at some point as standard headlines within wraps are supported for a while now.
 
-If you need text that is bold and italic, simply use it the other way around: ''%%**//No Headline//**%%''
+If that config options is enabled and you need text that is bold and italic, simply use it the other way around: ''%%**//No Headline//**%%''.
 
 
 === Multi-columns ===

--- a/helper.php
+++ b/helper.php
@@ -86,6 +86,9 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
         if ($this->getConf('darkTpl')) {
             $attr['class'] = (isset($attr['class']) ? $attr['class'].' ' : '').'wrap__dark';
         }
+        if ($this->getConf('emulatedHeadings')) {
+            $attr['class'] = (isset($attr['class']) ? $attr['class'].' ' : '').'wrap__emuhead';
+        }
 
         //get dir
         if($attr['lang']) {

--- a/lang/de-informal/settings.php
+++ b/lang/de-informal/settings.php
@@ -12,3 +12,4 @@ $lang['restrictionType'] = 'Beschränkungsart, setzt fest ob obige Klassen ein- 
 $lang['syntaxDiv'] = 'Welche Syntax soll die Werkzeugleiste für Block-Wraps verwenden?';
 $lang['syntaxSpan'] = 'Welche Syntax soll die Werkzeugleiste für Inline-Wraps verwenden?';
 $lang['darkTpl'] = 'Optimiere Farben für dunkle Templates?';
+$lang['emulatedHeadlines'] = 'Nutze nachgeahmte Überschriften? (veraltet)';

--- a/lang/de/settings.php
+++ b/lang/de/settings.php
@@ -12,3 +12,4 @@ $lang['restrictionType'] = 'Beschränkungsart, setzt fest ob obige Klassen ein- 
 $lang['syntaxDiv'] = 'Welche Syntax soll die Werkzeugleiste für Block-Wraps verwenden?';
 $lang['syntaxSpan'] = 'Welche Syntax soll die Werkzeugleiste für Inline-Wraps verwenden?';
 $lang['darkTpl'] = 'Optimiere Farben für dunkle Templates?';
+$lang['emulatedHeadlines'] = 'Nutze nachgeahmte Überschriften? (veraltet)';

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -12,3 +12,4 @@ $lang['restrictionType'] = 'Restriction type, specifies if classes above shall b
 $lang['syntaxDiv'] = 'Which syntax should be used in the toolbar picker for block wraps?';
 $lang['syntaxSpan'] = 'Which syntax should be used in the toolbar picker for inline wraps?';
 $lang['darkTpl'] = 'Optimise colours for dark templates?';
+$lang['emulatedHeadlines'] = 'Use emulated headings? (deprecated)';


### PR DESCRIPTION
Introduce new config option 'emulatedHeadlines', set to false by default, to deprecate emulated headlines.
The plan is to remove them altogether after two years.

This will close #131.