### PR TITLE
Force content colour of safety notes

### DIFF
--- a/style.less
+++ b/style.less
@@ -152,6 +152,14 @@ span.wrap_download { background-image: url(images/note/16/download.png); }
     color: #fff;
 }
 
+.wrap_danger *,
+.wrap_warning *,
+.wrap_caution *,
+.wrap_notice *,
+.wrap_safety * {
+    color: inherit !important;
+}
+
 
 /* mark
 ********************************************************************/


### PR DESCRIPTION
Safety notes are the only boxes which change the font colour of their content while also allowing all kinds of content. That can lead to less readable text, as reported in #126.
This change makes sure that the text stays the main font colour.

Please note, this could potentially have unintended consequences, in case there is supposed to be differently coloured text in there. Please report back if you find any such occurrence.