### PR TITLE
Make changing table widths optional

### DIFF
--- a/all.less
+++ b/all.less
@@ -11,11 +11,6 @@ Screen and Print Styles for the Wrap Plugin
     box-sizing: border-box;
 }
 
-/* tables in columns and boxes should span the whole width */
-.plugin_wrap table {
-    width: 100%;
-}
-
 /* emulate a headline
    (only with 'emulatedHeadlines' config option set)
    @deprecated 2018-03-20 */
@@ -282,6 +277,12 @@ span.wrap_round {
 
 /* miscellaneous
 ********************************************************************/
+
+/*____________ tablewidth ____________*/
+
+.wrap_tablewidth table {
+    width: 100%;
+}
 
 /*____________ indent ____________*/
 

--- a/example.txt
+++ b/example.txt
@@ -88,9 +88,6 @@ Normally you would only need the class ''column'', but for more sophisticated us
   * **''left''** will let you float your wrap on the left
   * **''right''** will let the wrap float right
   * **''center''** will position the wrap in the horizontal center of the page
-
-A **table** inside a column or box will always be **100% wide**. This makes positioning and sizing tables possible.
-
 </WRAP>
 
 <WRAP third column>
@@ -304,6 +301,20 @@ You can create a row of tabs by simply wrapping a list of links in ''%%<WRAP tab
 After using any of the float classes, you might come across following text protruding into the space where only the floating containers should be. To prevent that, you should simply add this after your last column:
 
   <WRAP clear />
+
+=== Table width ===
+
+You can set the width of a table via ''tablewidth'' as every table inside that wrap will always be 100% wide. This makes it possible to give tables any width by adding an additional width to the wrap (or none for 100%).
+
+<WRAP tablewidth 80%>
+^ Table ^ is ^
+| 80% | wide |
+</WRAP>
+
+  <WRAP tablewidth 80%>
+  ^ Table ^ is ^
+  | 80% | wide |
+  </WRAP>
 
 === Indent ===
 


### PR DESCRIPTION
Remove that all tables in all wraps are 100% wide.
Make that optional instead by adding a new class 'tablewidth'.

This is not backwards compatible, so existing 100% tables will now be smaller. But that can be fixed by adding the 'tablewidth' class to those wraps.
This was requested on the [plugin's discussion page](https://www.dokuwiki.org/plugin:wrap:discussion#requestmake_100_table_width_optional) and I think it makes sense to make it optional.