### PR TITLE
Small fixes

### DIFF
--- a/all.less
+++ b/all.less
@@ -23,7 +23,7 @@ Screen and Print Styles for the Wrap Plugin
 /* emulate a bigger headline with a bottom border */
 .plugin_wrap.wrap__emuhead em strong em.u {
     font-size: 115%;
-    border-bottom: 1px solid __border__;
+    border-bottom: 1px solid @ini_border;
     font-style: normal;
     text-decoration: none;
     display: block;
@@ -261,7 +261,7 @@ span.wrap_round {
 ********************************************************************/
 
 .wrap_lo {
-    color: __text_neu__;
+    color: @ini_text_neu;
     font-size: 85%;
 }
 .wrap_em {
@@ -342,7 +342,7 @@ div.wrap_spoiler {
 .wrap_button a:link,
 .wrap_button a:visited {
     background-image: none;
-    border: 1px solid __border__;
+    border: 1px solid @ini_border;
     border-radius: .3em;
     padding: .5em .7em;
     text-decoration: none;

--- a/example.txt
+++ b/example.txt
@@ -191,43 +191,43 @@ Center aligned text ...
 
 <WRAP info 300px left>
 === Info ===
-  <WRAP info></WRAP>
+%%<WRAP info></WRAP>%%
 </WRAP>
 
 
 <WRAP tip 300px left>
 === Tip ===
-  <WRAP tip></WRAP>
+%%<WRAP tip></WRAP>%%
 </WRAP>
 
 
 <WRAP important 300px left>
 === Important ===
-  <WRAP important></WRAP>
+%%<WRAP important></WRAP>%%
 </WRAP>
 
 
 <WRAP alert 300px left>
 === Alert ===
-  <WRAP alert></WRAP>
+%%<WRAP alert></WRAP>%%
 </WRAP>
 
 
 <WRAP round help 300px left>
 === Help ===
-  <WRAP round help></WRAP>
+%%<WRAP round help></WRAP>%%
 </WRAP>
 
 
 <WRAP download 300px left>
 === Download ===
-  <WRAP download></WRAP>
+%%<WRAP download></WRAP>%%
 </WRAP>
 
 
 <WRAP todo 300px left>
 === Todo ===
-  <WRAP todo></WRAP>
+%%<WRAP todo></WRAP>%%
 </WRAP>
 
 
@@ -236,29 +236,31 @@ Center aligned text ...
 
 **Safety Notes:**
 
+Best only use simple markup in safety notes.
+
 <WRAP danger 30% left>
 === Danger ===
-  <WRAP danger></WRAP>
+%%<WRAP danger></WRAP>%%
 </WRAP>
 
 <WRAP warning 30% left>
 === Warning ===
-  <WRAP warning></WRAP>
+%%<WRAP warning></WRAP>%%
 </WRAP>
 
 <WRAP caution 30% left>
 === Caution ===
-  <WRAP caution></WRAP>
+%%<WRAP caution></WRAP>%%
 </WRAP>
 
 <WRAP round notice 30% left>
 === Notice ===
-  <WRAP round notice></WRAP>
+%%<WRAP round notice></WRAP>%%
 </WRAP>
 
 <WRAP round safety 30% left>
 === Safety ===
-  <WRAP round safety></WRAP>
+%%<WRAP round safety></WRAP>%%
 </WRAP>
 
 <WRAP clear />

--- a/pdf.less
+++ b/pdf.less
@@ -3,9 +3,9 @@ Styles used in PDFs by the DW2PDF plugin (in addition to all.css, and
 the DW2PDF plugin also includes style.css via the 'usestyles' option)
 ********************************************************************/
 
-.dokuwiki {
-
 @import 'print_or_pdf.less';
+
+.dokuwiki {
 
 /*____________ only print ____________*/
 /* due to including style.css, these need to be overwritten again */

--- a/print.less
+++ b/print.less
@@ -2,9 +2,9 @@
 Print Styles for the Wrap Plugin (additional to all.css)
 ********************************************************************/
 
-.dokuwiki {
-
 @import 'print_or_pdf.less';
+
+.dokuwiki {
 
 /* boxes and notes with icons
 ********************************************************************/

--- a/print_or_pdf.less
+++ b/print_or_pdf.less
@@ -2,6 +2,8 @@
 Styles shared between print.css and pdf.css
 ********************************************************************/
 
+.dokuwiki {
+
 /* miscellaneous
 ********************************************************************/
 
@@ -23,3 +25,5 @@ Styles shared between print.css and pdf.css
 .wrap_noprint {
     display: none;
 }
+
+} /* /.dokuwiki */

--- a/style.less
+++ b/style.less
@@ -8,8 +8,8 @@ Screen Styles for the Wrap Plugin (additional to all.css)
 ********************************************************************/
 
 .wrap_box {
-    background: __background_alt__;
-    color: __text__;
+    background: @ini_background_alt;
+    color: @ini_text;
 }
 div.wrap_box,
 div.wrap_danger,
@@ -179,8 +179,8 @@ span.wrap_download { background-image: url(images/note/16/download.png); }
 /*____________ spoiler ____________*/
 
 .wrap_spoiler {
-    background-color: __background__ !important;
-    color: __background__ !important;
+    background-color: @ini_background !important;
+    color: @ini_background !important;
     border: 1px dotted red;
 }
 
@@ -201,7 +201,7 @@ span.wrap_download { background-image: url(images/note/16/download.png); }
 
 .wrap_button a:link,
 .wrap_button a:visited {
-    background-color: __background_alt__;
+    background-color: @ini_background_alt;
 }
 .wrap_button a:link:hover,
 .wrap_button a:visited:hover,
@@ -209,7 +209,7 @@ span.wrap_download { background-image: url(images/note/16/download.png); }
 .wrap_button a:visited:focus,
 .wrap_button a:link:active,
 .wrap_button a:visited:active {
-    background-color: __background_neu__;
+    background-color: @ini_background_neu;
 }
 
 } /* /.dokuwiki */


### PR DESCRIPTION
A couple of small fixes following recent PRs.

* Change style.ini placeholders to LESS syntax: I should really have done that as part of the move to LESS (#166). And it's also required to it possible to styles PDFs with the screen styles (#167).
* Make '.dokuwiki' scope more consistent in shared print and pdf styles: The same, should have been part of #166 and is required fro #167.
* Change code in boxes and notes to normal text: When forcing content colour of safety notes (#169), the colour of the code blocks in some of them were white on a light grey background. Instead of fixing that one case (out of probably many), I opted for adding a note saying safety boxes work best with simple markup and changing the code block to normal text. So that it doesn't look too weird, I also changed the code blocks of the boxes above to be normal text.
