### PR TITLE
Update travis script due to new DokuWiki release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ before_script:
   - wget https://phar.phpunit.de/phpunit-5.7.phar
   - cd _test
 script:
-  - if [ "$DOKUWIKI" = "master" ]; then phpunit --stderr --group plugin_wrap; fi
-  - if [ "$DOKUWIKI" != "master" ]; then php ../phpunit-5.7.phar --stderr --group plugin_wrap; fi
+  - if [ "$DOKUWIKI" != "old-stable" ]; then phpunit --stderr --group plugin_wrap; fi
+  - if [ "$DOKUWIKI" = "old-stable" ]; then php ../phpunit-5.7.phar --stderr --group plugin_wrap; fi


### PR DESCRIPTION
Due to DokuWiki's release today (and the next one after that) the `.travis.yml` file needs to be updated so that the correct PHPUnit version is used. See #161 for more info.