### PR TITLE
Feature update container height

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -53,9 +53,13 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
 
         foreach ($tokens as $token) {
 
-            //get width
+            //get width or/and height
             if (preg_match('/^\d*\.?\d+(%|px|em|rem|ex|ch|vw|vh|pt|pc|cm|mm|in)$/', $token)) {
-                $attr['width'] = $token;
+                if (strlen($attr['width']) > 0){
+					$attr['height'] = $token;
+				} else {
+					$attr['width'] = $token;
+				}
                 continue;
             }
 
@@ -118,10 +122,18 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
             // width on spans normally doesn't make much sense, but in the case of floating elements it could be used
             if($attr['width']) {
                 if (strpos($attr['width'],'%') !== false) {
-                    $out .= ' style="width: '.hsc($attr['width']).';"';
+                    if($attr['height']){
+						$out .= ' style="width: '.hsc($attr['width']).'; height: '.hsc($attr['height']).'; overflow: auto;"';
+					}else {
+						$out .= ' style="width: '.hsc($attr['width']).';"';
+					}
                 } else {
                     // anything but % should be 100% when the screen gets smaller
-                    $out .= ' style="width: '.hsc($attr['width']).'; max-width: 100%;"';
+                    if($attr['height']){
+						$out .= ' style="width: '.hsc($attr['width']).'; height: '.hsc($attr['height']).'; overflow: auto; max-width: 100%;"';
+					}else {
+						$out .= ' style="width: '.hsc($attr['width']).'; max-width: 100%;"';
+				    }
                 }
             }
             // only write lang if it's a language in lang2dir.conf

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base     wrap
 author   Anika Henke
 email    anika@selfthinker.org
-date     2018-04-22
+date     2019-03-22
 name     Wrap Plugin
 desc     Universal plugin which combines functionalities of many other plugins. Wrap wiki text inside containers (divs or spans) and give them a class (choose from a variety of preset classes), a width and/or a language with its associated text direction.
 url      https://www.dokuwiki.org/plugin:wrap


### PR DESCRIPTION
if you add 2 size parametes in syntax, the first is for container width (like it was before) - the second sets container height. If a height is set, the overflow attribut is set in html (scrollbars will be visible if necessary) 