### PR TITLE
Set default values in attr array.

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -30,7 +30,7 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
      */
     function getAttributes($data, $useNoPrefix=true) {
 
-        $attr = array();
+        $attr = array('lang' => false, 'class' => false, 'width' => false, 'id' => false, 'dir' => false);
         $tokens = preg_split('/\s+/', $data, 9);
 
         // anonymous function to convert inclusive comma separated items to regex pattern

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base     wrap
 author   Anika Henke
 email    anika@selfthinker.org
-date     2018-04-22
+date     2022-08-08
 name     Wrap Plugin
 desc     Universal plugin which combines functionalities of many other plugins. Wrap wiki text inside containers (divs or spans) and give them a class (choose from a variety of preset classes), a width and/or a language with its associated text direction.
 url      https://www.dokuwiki.org/plugin:wrap


### PR DESCRIPTION
Fixed PHP 8.1 errors caused by lines like:

```php
if($attr['dir'])
// Warning: Undefined array key "dir" in /lib/plugins/wrap/helper.php on line 128
```
By initializing hte `$attr` array with default false values.

```php
$attr = array('lang' => false, 'class' => false, 'width' => false, 'id' => false, 'dir' => false);
```

Fixes issue #236 & #234.