### PR TITLE
Cleanup

### DIFF
--- a/action.php
+++ b/action.php
@@ -6,12 +6,6 @@
  * @author     Andreas Gohr <andi@splitbrain.org>
  */
 
-// must be run within Dokuwiki
-if(!defined('DOKU_INC')) die();
-
-if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
-require_once(DOKU_PLUGIN.'action.php');
-
 class action_plugin_wrap extends DokuWiki_Action_Plugin {
 
     /**

--- a/helper.php
+++ b/helper.php
@@ -11,11 +11,12 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
                                      'wrap_info', 'wrap_important', 'wrap_alert', 'wrap_tip', 'wrap_help', 'wrap_todo',
                                      'wrap_download', 'wrap_hi', 'wrap_spoiler');
     static protected $paragraphs = array ('wrap_leftalign', 'wrap_rightalign', 'wrap_centeralign', 'wrap_justify');
-    static protected $column_count = 0;
     static $box_left_pos = 0;
     static $box_right_pos = 0;
     static $box_first = true;
     static $table_entr = 0;
+
+    protected $column_count = 0;
 
     /**
      * get attributes (pull apart the string between '<wrap' and '>')

--- a/helper.php
+++ b/helper.php
@@ -64,7 +64,7 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
             }
 
             //get lang
-            if (preg_match('/\:([a-z\-]+)/', $token)) {
+            if (preg_match('/:([a-z\-]+)/', $token)) {
                 $attr['lang'] = trim($token,':');
                 continue;
             }

--- a/helper.php
+++ b/helper.php
@@ -6,9 +6,6 @@
  * @author     Anika Henke <anika@selfthinker.org>
  */
 
-// must be run within Dokuwiki
-if(!defined('DOKU_INC')) die();
-
 class helper_plugin_wrap extends DokuWiki_Plugin {
     static protected $boxes = array ('wrap_box', 'wrap_danger', 'wrap_warning', 'wrap_caution', 'wrap_notice', 'wrap_safety',
                                      'wrap_info', 'wrap_important', 'wrap_alert', 'wrap_tip', 'wrap_help', 'wrap_todo',

--- a/syntax/closesection.php
+++ b/syntax/closesection.php
@@ -6,11 +6,6 @@
  * @author     Michael Hamann <michael@content-space.de>
  */
 
-if(!defined('DOKU_INC')) die();
-
-if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
-require_once(DOKU_PLUGIN.'syntax.php');
-
 class syntax_plugin_wrap_closesection extends DokuWiki_Syntax_Plugin {
 
     function getType(){ return 'substition';}
@@ -26,8 +21,8 @@ class syntax_plugin_wrap_closesection extends DokuWiki_Syntax_Plugin {
     /**
      * Create output
      */
-    function render($mode, Doku_Renderer $renderer, $indata) {
-        if($mode == 'xhtml'){
+    function render($format, Doku_Renderer $renderer, $data) {
+        if($format == 'xhtml'){
             /** @var Doku_Renderer_xhtml $renderer */
             $renderer->finishSectionEdit();
             return true;

--- a/syntax/div.php
+++ b/syntax/div.php
@@ -6,11 +6,6 @@
  * @author     Anika Henke <anika@selfthinker.org>
  */
 
-if(!defined('DOKU_INC')) die();
-
-if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
-require_once(DOKU_PLUGIN.'syntax.php');
-
 class syntax_plugin_wrap_div extends DokuWiki_Syntax_Plugin {
     protected $special_pattern = '<div\b[^>\r\n]*?/>';
     protected $entry_pattern   = '<div\b.*?>(?=.*?</div>)';
@@ -79,13 +74,13 @@ class syntax_plugin_wrap_div extends DokuWiki_Syntax_Plugin {
     /**
      * Create output
      */
-    function render($mode, Doku_Renderer $renderer, $indata) {
+    function render($format, Doku_Renderer $renderer, $indata) {
         static $type_stack = array ();
 
         if (empty($indata)) return false;
         list($state, $data) = $indata;
 
-        if($mode == 'xhtml'){
+        if($format == 'xhtml'){
             /** @var Doku_Renderer_xhtml $renderer */
             switch ($state) {
                 case DOKU_LEXER_ENTER:
@@ -119,7 +114,7 @@ class syntax_plugin_wrap_div extends DokuWiki_Syntax_Plugin {
             }
             return true;
         }
-        if($mode == 'odt'){
+        if($format == 'odt'){
             switch ($state) {
                 case DOKU_LEXER_ENTER:
                     $wrap = plugin_load('helper', 'wrap');

--- a/syntax/divblock.php
+++ b/syntax/divblock.php
@@ -8,8 +8,6 @@
  * @author     Anika Henke <anika@selfthinker.org>
  */
 
-require_once(dirname(__FILE__).'/div.php');
-
 class syntax_plugin_wrap_divblock extends syntax_plugin_wrap_div {
 
     protected $special_pattern = '<block\b[^>\r\n]*?/>';

--- a/syntax/divwrap.php
+++ b/syntax/divwrap.php
@@ -8,8 +8,6 @@
  * @author     Anika Henke <anika@selfthinker.org>
  */
 
-require_once(dirname(__FILE__).'/div.php');
-
 class syntax_plugin_wrap_divwrap extends syntax_plugin_wrap_div {
 
     protected $special_pattern = '<WRAP\b[^>\r\n]*?/>';

--- a/syntax/span.php
+++ b/syntax/span.php
@@ -6,11 +6,6 @@
  * @author     Anika Henke <anika@selfthinker.org>
  */
 
-if(!defined('DOKU_INC')) die();
-
-if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
-require_once(DOKU_PLUGIN.'syntax.php');
-
 class syntax_plugin_wrap_span extends DokuWiki_Syntax_Plugin {
     protected $special_pattern = '<span\b[^>\r\n]*?/>';
     protected $entry_pattern   = '<span\b.*?>(?=.*?</span>)';
@@ -62,13 +57,13 @@ class syntax_plugin_wrap_span extends DokuWiki_Syntax_Plugin {
     /**
      * Create output
      */
-    function render($mode, Doku_Renderer $renderer, $indata) {
+    function render($format, Doku_Renderer $renderer, $indata) {
         static $type_stack = array ();
 
         if (empty($indata)) return false;
         list($state, $data) = $indata;
 
-        if($mode == 'xhtml'){
+        if($format == 'xhtml'){
             switch ($state) {
                 case DOKU_LEXER_ENTER:
                 case DOKU_LEXER_SPECIAL:
@@ -85,7 +80,7 @@ class syntax_plugin_wrap_span extends DokuWiki_Syntax_Plugin {
             }
             return true;
         }
-        if($mode == 'odt'){
+        if($format == 'odt'){
             switch ($state) {
                 case DOKU_LEXER_ENTER:
                     $wrap = plugin_load('helper', 'wrap');

--- a/syntax/spaninline.php
+++ b/syntax/spaninline.php
@@ -8,8 +8,6 @@
  * @author     Anika Henke <anika@selfthinker.org>
  */
 
-require_once(dirname(__FILE__).'/span.php');
-
 class syntax_plugin_wrap_spaninline extends syntax_plugin_wrap_span {
 
     protected $special_pattern = '<inline\b[^>\r\n]*?/>';

--- a/syntax/spanwrap.php
+++ b/syntax/spanwrap.php
@@ -8,8 +8,6 @@
  * @author     Anika Henke <anika@selfthinker.org>
  */
 
-require_once(dirname(__FILE__).'/span.php');
-
 class syntax_plugin_wrap_spanwrap extends syntax_plugin_wrap_span {
 
     protected $special_pattern = '<wrap\b[^>\r\n]*?/>';


### PR DESCRIPTION
Deleted some old defines and requires
simplify a regexp, little formating

Only deprecated calls to `_addCall()` not yet replaced. As it will break backward compatibility already.