### PR TITLE
Make tests compatible with Igor

### DIFF
--- a/_test/wrap_syntax.test.php
+++ b/_test/wrap_syntax.test.php
@@ -6,10 +6,8 @@
  * @group plugins
  */
 class plugin_wrap_test extends DokuWikiTest {
-    public function setUp() {
-        $this->pluginsEnabled[] = 'wrap';
-        parent::setUp();
-    }
+
+    protected $pluginsEnabled = ['wrap'];
 
     public function test_nestedheading() {
         $instructions = p_get_instructions("<WRAP>\n==== Heading ====\n\nSome text\n</WRAP>");


### PR DESCRIPTION
`setUp()` method signature was no longer compatible with the testing framework on Igor, so simplified with direct override of `$pluginsEnabled` variable