### PR TITLE
Use <mark> for highlighting

### DIFF
--- a/action.php
+++ b/action.php
@@ -26,6 +26,7 @@ class action_plugin_wrap extends DokuWiki_Action_Plugin {
             'type' => 'picker',
             'title' => $this->getLang('picker'),
             'icon' => '../../plugins/wrap/images/toolbar/picker.png',
+			'id' => 'edtb_wrapmenu',
             'list' => array(
                 array(
                     'type'   => 'format',
@@ -108,7 +109,7 @@ class action_plugin_wrap extends DokuWiki_Action_Plugin {
                     'title'  => $this->getLang('hi'),
                     'icon'   => '../../plugins/wrap/images/toolbar/hi.png',
                     'open'   => '<mark>',
-                    'close'  => '</mark>', /* use more semantic markup here! */
+                    'close'  => '</mark>' /* use more semantic markup here! */
                 ),
                 array(
                     'type'   => 'format',

--- a/action.php
+++ b/action.php
@@ -107,8 +107,8 @@ class action_plugin_wrap extends DokuWiki_Action_Plugin {
                     'type'   => 'format',
                     'title'  => $this->getLang('hi'),
                     'icon'   => '../../plugins/wrap/images/toolbar/hi.png',
-                    'open'   => '<'.$syntaxSpan.' hi>',
-                    'close'  => '</'.$syntaxSpan.'>',
+                    'open'   => '<mark>',
+                    'close'  => '</mark>', /* use more semantic markup here! */
                 ),
                 array(
                     'type'   => 'format',

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -15,5 +15,5 @@ $lang['todo']      = 'todo box';
 $lang['clear']     = 'clear floats';
 
 $lang['em']        = 'especially emphasised';
-$lang['hi']        = 'highlighted';
+$lang['hi']        = 'mark';
 $lang['lo']        = 'less significant';

--- a/lang/es/lang.php
+++ b/lang/es/lang.php
@@ -17,5 +17,5 @@ $lang['download']              = 'caja de descarga';
 $lang['todo']                  = 'caja de TODO';
 $lang['clear']                 = 'limpiar float';
 $lang['em']                    = 'especialmente enfatizado';
-$lang['hi']                    = 'destacado';
+$lang['hi']                    = 'marcado';   /* updated for new markers */
 $lang['lo']                    = 'menos significativo';

--- a/lang/no/lang.php
+++ b/lang/no/lang.php
@@ -17,8 +17,6 @@ $lang['help']                  = 'hjelpeboks';
 $lang['download']              = 'nedlastningsboks';
 $lang['todo']                  = 'gjøremålsboks';
 $lang['clear']                 = 'tøm floats';
-$lang['em']                    = 'spesielt fremhevet (singular)
-spesielt fremhevede (plural)';
-$lang['hi']                    = 'markert (singular)
-markerte (plural)';
+$lang['em']                    = 'spesielt fremhevet';
+$lang['hi']                    = 'markert';  /* updated for new markers */
 $lang['lo']                    = 'mindre viktig';

--- a/lang/sv/lang.php
+++ b/lang/sv/lang.php
@@ -13,5 +13,5 @@ $lang['important']             = 'viktigt-box';
 $lang['help']                  = 'hjälp-box';
 $lang['download']              = 'nedladdningsbox';
 $lang['todo']                  = 'att böra-box';
-$lang['hi']                    = 'förstärkt';
+$lang['hi']                    = 'markerad'; /* updated for new markers */
 $lang['lo']                    = 'mindre betydelsefullt';

--- a/syntax/div.php
+++ b/syntax/div.php
@@ -10,6 +10,7 @@ class syntax_plugin_wrap_div extends DokuWiki_Syntax_Plugin {
     protected $special_pattern = '<div\b[^>\r\n]*?/>';
     protected $entry_pattern   = '<div\b.*?>(?=.*?</div>)';
     protected $exit_pattern    = '</div>';
+	protected $output_tag      = 'div';
 
     function getType(){ return 'formatting';}
     function getAllowedTypes() { return array('container', 'formatting', 'substition', 'protected', 'disabled', 'paragraphs'); }
@@ -103,12 +104,12 @@ class syntax_plugin_wrap_div extends DokuWiki_Syntax_Plugin {
                     $wrap = $this->loadHelper('wrap');
                     $attr = $wrap->buildAttributes($data, 'plugin_wrap');
 
-                    $renderer->doc .= '<div'.$attr.'>';
-                    if ($state == DOKU_LEXER_SPECIAL) $renderer->doc .= '</div>';
+                    $renderer->doc .= '<'.$this->output_tag.$attr.'>';
+                    if ($state == DOKU_LEXER_SPECIAL) $renderer->doc .= '</'.$this->output_tag.'>';
                     break;
 
                 case DOKU_LEXER_EXIT:
-                    $renderer->doc .= '</div>';
+                    $renderer->doc .= '</'.$this->output_tag.'>';
                     $renderer->finishSectionEdit();
                     break;
             }
@@ -118,7 +119,7 @@ class syntax_plugin_wrap_div extends DokuWiki_Syntax_Plugin {
             switch ($state) {
                 case DOKU_LEXER_ENTER:
                     $wrap = plugin_load('helper', 'wrap');
-                    array_push ($type_stack, $wrap->renderODTElementOpen($renderer, 'div', $data));
+                    array_push ($type_stack, $wrap->renderODTElementOpen($renderer, $this->output_tag, $data));
                     break;
 
                 case DOKU_LEXER_EXIT:

--- a/syntax/span.php
+++ b/syntax/span.php
@@ -10,6 +10,7 @@ class syntax_plugin_wrap_span extends DokuWiki_Syntax_Plugin {
     protected $special_pattern = '<span\b[^>\r\n]*?/>';
     protected $entry_pattern   = '<span\b.*?>(?=.*?</span>)';
     protected $exit_pattern    = '</span>';
+	protected $output_tag      = 'span';
 
     function getType(){ return 'formatting';}
     function getAllowedTypes() { return array('formatting', 'substition', 'disabled'); }
@@ -70,12 +71,12 @@ class syntax_plugin_wrap_span extends DokuWiki_Syntax_Plugin {
                     $wrap = $this->loadHelper('wrap');
                     $attr = $wrap->buildAttributes($data);
 
-                    $renderer->doc .= '<span'.$attr.'>';
-                    if ($state == DOKU_LEXER_SPECIAL) $renderer->doc .= '</span>';
+                    $renderer->doc .= '<'.$this->output_tag.$attr.'>';
+                    if ($state == DOKU_LEXER_SPECIAL) $renderer->doc .= '</'.$this->output_tag.'>';
                     break;
 
                 case DOKU_LEXER_EXIT:
-                    $renderer->doc .= '</span>';
+                    $renderer->doc .= '</'.$this->output_tag.'>';
                     break;
             }
             return true;
@@ -84,7 +85,7 @@ class syntax_plugin_wrap_span extends DokuWiki_Syntax_Plugin {
             switch ($state) {
                 case DOKU_LEXER_ENTER:
                     $wrap = plugin_load('helper', 'wrap');
-                    array_push ($type_stack, $wrap->renderODTElementOpen($renderer, 'span', $data));
+                    array_push ($type_stack, $wrap->renderODTElementOpen($renderer, $this->output_tag, $data));
                     break;
 
                 case DOKU_LEXER_EXIT:

--- a/syntax/spanmark.php
+++ b/syntax/spanmark.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Mark (highlight) syntax component for the wrap plugin
+ *
+ * Defines  <mark> ... </mark> syntax
+ *
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author     Anika Henke <anika@selfthinker.org>
+ */
+
+class syntax_plugin_wrap_spanmark extends syntax_plugin_wrap_span {
+
+    protected $special_pattern = '<mark\b[^>\r\n]*?/>';
+    protected $entry_pattern   = '<mark\b.*?>(?=.*?</mark>)';
+    protected $exit_pattern    = '</mark>';
+	protected $output_tag      = 'mark';
+
+}


### PR DESCRIPTION
This is a small change that makes the wrap plugin use `<mark>` instead of `<span hi>` for the highlight button.

A side-effect of this change is that it will also make it easier to add more tags, which may be important in the future when DokuWiki will no longer allow embedding HTML code.