### PR TITLE
Fix "Empty regular expression" PHP8 Warning

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -84,7 +84,7 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
                 if ($restrictionType xor $classIsInList) continue;
             }
             // prefix adjustment of class name
-            $prefix = (preg_match($noPrefix, $token)) ? '' : 'wrap_';
+            $prefix = (!empty($noPrefix) && preg_match($noPrefix, $token)) ? '' : 'wrap_';
             $attr['class'] = (isset($attr['class']) ? $attr['class'].' ' : '').$prefix.$token;
         }
         if ($this->getConf('darkTpl')) {


### PR DESCRIPTION
Hello,
When using [ODT](https://www.dokuwiki.org/plugin:odt) plugin to export a DokuWiki page (in attachment) with ``display_errors`` PHP8 directive set as ON, the following error was being thrown:

```
Warning: preg_match(): Empty regular expression in /home/eduardo/public_html/wiki/lib/plugins/wrap/helper.php on line 87
```

This PR ensures that ``$noPrefix`` isn't empty (because it can be, as can be seen here: https://github.com/selfthinker/dokuwiki_plugin_wrap/blob/master/helper.php#L49) before using it as a RegEx pattern.

Here's my ``noPrefix`` Wrap config (not seems to be related with this issue): ``tabs, group,admonition,danger,caution,note``

[cnh.txt](https://github.com/selfthinker/dokuwiki_plugin_wrap/files/11321278/cnh.txt)
