### PR TITLE
Fixed issue #267: PHP warnings about margins in helper.php.

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -463,10 +463,10 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
         // Frames/Textboxes still have some issues with formatting (at least in LibreOffice)
         // So as a workaround we implement columns as a table.
         // This is why we now use the margin of the div as the padding for the ODT table.
-        $properties ['padding-left'] = $properties ['margin-left'];
-        $properties ['padding-right'] = $properties ['margin-right'];
-        $properties ['padding-top'] = $properties ['margin-top'];
-        $properties ['padding-bottom'] = $properties ['margin-bottom'];
+        $properties ['padding-left'] = $properties ['margin-left'] ?? null;
+        $properties ['padding-right'] = $properties ['margin-right'] ?? null;
+        $properties ['padding-top'] = $properties ['margin-top'] ?? null;
+        $properties ['padding-bottom'] = $properties ['margin-bottom'] ?? null;
         $properties ['margin-left'] = null;
         $properties ['margin-right'] = null;
         $properties ['margin-top'] = null;

--- a/helper.php
+++ b/helper.php
@@ -395,7 +395,7 @@ class helper_plugin_wrap extends DokuWiki_Plugin {
             if ( $is_indent === true ) {
                 // FIXME: Has to be adjusted if test direction will be supported.
                 // See all.css
-                $properties ['margin-left'] = $properties ['padding-left'];
+                $properties ['margin-left'] = $properties ['padding-left'] ?? null;
                 $properties ['padding-left'] = 0;
                 $name .= 'Indent';
             }


### PR DESCRIPTION
```
PHP Warning:  Undefined array key "padding-left" in .../public_html/wiki/lib/plugins/wrap/helper.php on line 398
PHP Warning:  Undefined array key "margin-left" in .../public_html/wiki/lib/plugins/wrap/helper.php on line 466
PHP Warning:  Undefined array key "margin-right" in .../public_html/wiki/lib/plugins/wrap/helper.php on line 467
PHP Warning:  Undefined array key "margin-top" in .../public_html/wiki/lib/plugins/wrap/helper.php on line 468
PHP Warning:  Undefined array key "margin-bottom" in .../public_html/wiki/lib/plugins/wrap/helper.php on line 469
```
 - Using master branch, not the package from dokuwiki.
 - PHP 8.1 here.